### PR TITLE
Ref change

### DIFF
--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -82,6 +82,14 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version_minor }}
             type=sha,prefix=sha-
 
+      # A registry reference has to be lowercase and github.repository_owner is not — it is the
+      # account name as spelled, "Flickersoft". metadata-action normalises the image name for the
+      # tags it emits above, which is why env.IMAGE can carry it verbatim; cache-from and cache-to
+      # are handed to buildx as written and so need the owner folded here. ${VAR,,} is bash, which
+      # is the default shell for `run` on the Linux runners.
+      - id: cache
+        run: echo "ref=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/serval-server-buildcache:main" >>"$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v7
         with:
           # Repo root: the Server project references ../../Shared/*.
@@ -122,5 +130,5 @@ jobs:
           # image-manifest + oci-mediatypes are required: GHCR rejects BuildKit's default cache
           # manifest format. Its own package rather than a tag on serval-server, so the cache blobs
           # do not appear in the tag list a deployment picks an image from.
-          cache-from: type=registry,ref=${{ env.IMAGE }}-buildcache:main
-          cache-to: type=registry,ref=${{ env.IMAGE }}-buildcache:main,mode=max,image-manifest=true,oci-mediatypes=true
+          cache-from: type=registry,ref=${{ steps.cache.outputs.ref }}
+          cache-to: type=registry,ref=${{ steps.cache.outputs.ref }},mode=max,image-manifest=true,oci-mediatypes=true

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -102,7 +102,25 @@ jobs:
           # Keeps the .NET restore + apt layers warm between pushes, which is what makes a
           # source-only change a short build.
           # Also what keeps the Edge TPU natives cheap: the TensorFlow clone and CMake build of
-          # libtensorflowlite_c.so is minutes of work that only re-runs when TF_TAG changes, so a
+          # libtensorflowlite_c.so is ~9 minutes of work that only re-runs when TF_TAG changes, so a
           # source-only edit never pays for it.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          #
+          # A registry rather than the Actions cache, for two reasons that both make `type=gha`
+          # unable to hold this particular cache:
+          #
+          #   * Actions caches are scoped by the ref that wrote them, and this workflow builds from
+          #     tags as well as main (see the `create` trigger above). A tag run writes under
+          #     refs/tags/..., which a later push to main cannot read — so the most expensive builds
+          #     produce a cache nothing can use. A registry ref has no such scoping: every run here
+          #     reads and writes the same one.
+          #   * Actions caches share a 10 GB per-repository budget with ci.yml, whose Flutter SDK
+          #     (1.6 GB) and NuGet (~650 MB) entries exist per-ref and are touched on every pull
+          #     request. BuildKit's ~3.6 GB of blobs are touched only when an image is built, so
+          #     under LRU they are always the first eviction — the cache is not merely cold, it is
+          #     structurally unable to stay warm.
+          #
+          # image-manifest + oci-mediatypes are required: GHCR rejects BuildKit's default cache
+          # manifest format. Its own package rather than a tag on serval-server, so the cache blobs
+          # do not appear in the tag list a deployment picks an image from.
+          cache-from: type=registry,ref=${{ env.IMAGE }}-buildcache:main
+          cache-to: type=registry,ref=${{ env.IMAGE }}-buildcache:main,mode=max,image-manifest=true,oci-mediatypes=true


### PR DESCRIPTION
## What this changes, and why

<!-- One change per pull request. A branch that fixes a bug and reformats two files is two reviews
     wearing a trenchcoat. -->

Closes #

## What you tested

<!-- Especially for camera-dependent work: name the camera and say what you saw. A reviewer
     probably cannot reproduce it. -->

## Checks

<!-- These are the same checks .github/workflows/ci.yml runs. Ticking them locally is faster than
     finding out from a red check. -->

- [x] `dotnet build Serval.slnx` — no warnings, not just no errors
- [x] `dotnet test Serval.slnx`
- [x] `dart format .` in `App/serval_app` reports no files changed
- [x] `flutter analyze` is silent, info included
- [x] `flutter test` passes — and if the design changed, `flutter test --update-goldens` and the
      new captures are committed in this branch
- [x] `pubspec.lock` is committed alongside any `pubspec.yaml` edit (CI resolves with
      `--enforce-lockfile`)
- [x] I have signed the [CLA](https://github.com/Flickersoft/serval/blob/main/CLA.md), or will when
      the bot asks
