### PR TITLE
Fix Flakey test

### DIFF
--- a/Server/Serval.Server.Tests/DetectFrameReaderTests.cs
+++ b/Server/Serval.Server.Tests/DetectFrameReaderTests.cs
@@ -173,6 +173,16 @@ public class DetectFrameReaderTests
                 WriteFrame(dir, 0);
                 (await subscription.ReadAsync(token)).Return();
 
+                // The reader hands the frame over before it unlinks the file, so holding one says
+                // nothing about whether the sweep has got there yet. Waiting for it is the
+                // assertion; the token WithReaderAsync bounds is what makes a delete that never
+                // comes a failure with the leftovers named rather than a hang.
+                while (Directory.EnumerateFiles(dir, "frame-*.yuv").Any()
+                       && !token.IsCancellationRequested)
+                {
+                    await Task.Delay(20, CancellationToken.None);
+                }
+
                 Assert.Empty(Directory.EnumerateFiles(dir, "frame-*.yuv"));
             });
         }


### PR DESCRIPTION
## What this changes, and why

This test had a race condition.

Closes #

## What you tested

<!-- Especially for camera-dependent work: name the camera and say what you saw. A reviewer
     probably cannot reproduce it. -->

## Checks

<!-- These are the same checks .github/workflows/ci.yml runs. Ticking them locally is faster than
     finding out from a red check. -->

- [x] `dotnet build Serval.slnx` — no warnings, not just no errors
- [x] `dotnet test Serval.slnx`
- [x] `dart format .` in `App/serval_app` reports no files changed
- [x] `flutter analyze` is silent, info included
- [x] `flutter test` passes — and if the design changed, `flutter test --update-goldens` and the
      new captures are committed in this branch
- [x] `pubspec.lock` is committed alongside any `pubspec.yaml` edit (CI resolves with
      `--enforce-lockfile`)
- [x] I have signed the [CLA](https://github.com/Flickersoft/serval/blob/main/CLA.md), or will when
      the bot asks
