### PR TITLE
Change versioning

### DIFF
--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -11,8 +11,8 @@ on:
       - "App/serval_app/**"
       - ".dockerignore"
       - ".github/workflows/server-image.yml"
-  # Pushing a v<major>.<minor>.0 tag is how the minor is bumped, and the .0 it names has to get an
-  # image of its own even though the commit it points at was probably built already.
+  # Pushing a v<major>.<minor>.<patch> tag is how a release is cut, and the version it names has to
+  # get an image of its own even though the commit it points at was probably built already.
   #
   # `create` rather than a tags: entry under push: above — the paths filter applies to every push
   # event, and a tag introduces no files, so a tag push can match nothing and be silently skipped.
@@ -40,18 +40,22 @@ jobs:
           # a poor trade on a job that then spends minutes compiling llama.cpp.
           fetch-depth: 0
 
-      # The version is the nearest v<major>.<minor>.0 tag with the commits since it as the patch:
-      # v0.1.0 plus 7 commits is 0.1.7. Bumping the minor is therefore `git tag v0.2.0`, and the
-      # patch takes care of itself. No tag at all fails this step outright, which is the point —
-      # there is no version to guess and a build that invented one would collide with a real
-      # release.
+      # A release names its own version: the tag is the answer, so `git tag v0.4.2` publishes 0.4.2
+      # and nothing else has a say. A build off main is not a release and has no version of its
+      # own — it stamps the last release, and SOURCE_REVISION below is what identifies the build.
+      #
+      # Numeric x.y.z either way, because the Dockerfile hands this to -p:VersionPrefix, which
+      # takes major.minor.patch and rejects a prerelease suffix. No tag at all fails this step
+      # outright, which is the point — there is no version to guess.
       - id: version
         run: |
-          described=$(git describe --tags --match 'v[0-9]*' --long)
-          version=$(printf '%s' "${described#v}" | awk -F- '{split($1,v,"."); print v[1]"."v[2]"."$2}')
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            version=${GITHUB_REF#refs/tags/v}
+          else
+            version=$(git describe --tags --match 'v[0-9]*' --abbrev=0 | sed 's/^v//')
+          fi
           echo "version=$version" >>"$GITHUB_OUTPUT"
-          echo "version_minor=${version%.*}" >>"$GITHUB_OUTPUT"
-          echo "Building $version from $described" >>"$GITHUB_STEP_SUMMARY"
+          echo "Building $version" >>"$GITHUB_STEP_SUMMARY"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -66,20 +70,25 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
-          # Four tags, narrowing from "whatever is newest" to one exact build:
-          #   latest      moves every push to main — what an unpinned deployment follows
-          #   0.1         moves within a minor — patches arrive, the shape does not change
-          #   0.1.7       one release, never rewritten
-          #   sha-abc1234 one commit; rolling back on the NAS is editing :latest to this
+          # Two streams. A tag push is a release and takes the three tags an unpinned, a
+          # minor-pinned and an exactly-pinned deployment follow:
+          #   latest      moves to the newest release — what deploy/docker-compose.yml defaults to
+          #   0.4         moves within a minor — patches arrive, the shape does not change
+          #   0.4.2       one release, never rewritten
           #
-          # latest is held to the default branch so that tagging an *older* commit publishes its
-          # version without dragging latest backwards. type=raw rather than type=semver throughout:
-          # type=semver reads the tag off the ref and so produces nothing on the push-to-main builds
-          # that are most of them, while the version step's answer is right for both.
+          # A push to main is not a release. It gets `edge` and its sha and consumes no version
+          # number, so a failed build or a commit the paths filter skips cannot burn one:
+          #   edge        moves every push to main — head, for a deployment that wants it
+          #   sha-abc1234 one commit; rolling back on the NAS is editing the tag to this
+          #
+          # latest is gated on the ref being a tag rather than on the branch, so a push to main
+          # cannot drag it onto an unreleased build. {{major}}.{{minor}} reads the tag off the ref
+          # and so emits nothing on a main build, which is the behaviour wanted here.
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=${{ steps.version.outputs.version_minor }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable={{is_default_branch}}
             type=sha,prefix=sha-
 
       # A registry reference has to be lowercase and github.repository_owner is not — it is the

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -58,33 +58,33 @@ the CPU-only variant; the local compose file does this, since a dev box does not
 
 ## Versions and image tags
 
-Every build publishes four tags, and which one a deployment pins to is the whole update policy:
+Which tag a deployment pins to is the whole update policy:
 
 | Tag | Moves | Pin to it when |
 | --- | --- | --- |
-| `latest` | every push to `main` | you want whatever is newest and will notice if it breaks |
-| `0.1` | within a minor | you want fixes without the shape changing under you |
-| `0.1.7` | never | you want this exact release and nothing else |
+| `latest` | to each new release | you want the newest release, unattended |
+| `0.4` | within a minor | you want fixes without the shape changing under you |
+| `0.4.2` | never | you want this exact release and nothing else |
+| `edge` | every push to `main` | you want head and will notice if it breaks |
 | `sha-abc1234` | never | you are rolling back to a build you have already run |
 
-The number itself is derived, not stored. A `v<major>.<minor>.0` git tag names the release, and the
-patch is the count of commits since it — `v0.1.0` plus seven commits is `0.1.7`. So **bumping the
-minor is one command**, and the patch never needs touching:
+A release is a git tag and nothing else. The tag names the version, so any version is available —
+patch, minor or major:
 
 ```bash
-git tag v0.2.0 && git push origin v0.2.0
+git tag v0.4.2 && git push origin v0.4.2
 ```
 
-Two consequences worth knowing. The patch counts *commits*, not releases, so merging a branch
-advances it by the whole branch and leaves gaps — squash-merging keeps it to one per change. And a
-build made outside the workflow reports `0.0.0-dev`, because it has no tags to describe against and
-inventing a number would collide with a real one.
+A push to `main` is not a release. It publishes `edge` and its `sha-` tag, consumes no version
+number, and stamps the last released version into the assembly — the revision is what tells two
+`edge` builds apart. A build made outside the workflow reports `0.0.0-dev`, because it has no tags
+to describe against and inventing a number would collide with a real one.
 
 `GET /api/system/version` reads it back off the running assembly:
 
 ```console
 $ curl -s -H "Authorization: Bearer $TOKEN" http://<host>:8080/api/system/version
-{"version":"0.1.7","revision":"abc1234…"}
+{"version":"0.4.2","revision":"abc1234…"}
 ```
 
 The App shows the same pair under *Source* in the icon rail — the version to quote, the commit
@@ -97,8 +97,9 @@ real deployed stack (TrueNAS SCALE Apps, AMD iGPU), as opposed to the dev one ab
 in the ways the host forces:
 
 - **No `build:`** — TrueNAS Apps only runs pre-built images, so the server image comes from GHCR,
-  pushed by [.github/workflows/server-image.yml](../.github/workflows/server-image.yml) on
-  every push to `main`. `pull_policy: always` makes stop→start in the Apps UI the update loop.
+  pushed by [.github/workflows/server-image.yml](../.github/workflows/server-image.yml). On
+  `:latest` that is each new release; switch the tag to `:edge` to follow `main` instead.
+  `pull_policy: always` makes stop→start in the Apps UI the update loop.
 - **Bind mounts on ZFS datasets** rather than named volumes, so recordings and the database sit
   on the pool where they are visible and snapshottable.
 - **Model weights mounted at `/app/models`**, never baked into the image — 3.5 GB that changes


### PR DESCRIPTION
## What this changes, and why

Need to change how we version this.

Closes #

## What you tested

<!-- Especially for camera-dependent work: name the camera and say what you saw. A reviewer
     probably cannot reproduce it. -->

## Checks

<!-- These are the same checks .github/workflows/ci.yml runs. Ticking them locally is faster than
     finding out from a red check. -->

- [x] `dotnet build Serval.slnx` — no warnings, not just no errors
- [x] `dotnet test Serval.slnx`
- [x] `dart format .` in `App/serval_app` reports no files changed
- [x] `flutter analyze` is silent, info included
- [x] `flutter test` passes — and if the design changed, `flutter test --update-goldens` and the
      new captures are committed in this branch
- [x] `pubspec.lock` is committed alongside any `pubspec.yaml` edit (CI resolves with
      `--enforce-lockfile`)
- [x] I have signed the [CLA](https://github.com/Flickersoft/serval/blob/main/CLA.md), or will when
      the bot asks
