### PR TITLE
Object detection improvements, alert fix

### DIFF
--- a/Docs/alerts.md
+++ b/Docs/alerts.md
@@ -143,15 +143,24 @@ On startup the worker resolves every alert a previous run left `pending` — bou
 
 Object alerts are raised from
 [`CameraAiCoordinator.StoreAsync`](../Server/Serval.Server/Ai/CameraAiCoordinator.cs), **while the
-episode is still open** — above the early return that skips storage. Whether an episode is an alert
-is decided when it opens and never revised, so waiting for the close would delay the queue by
-`AbsenceSeconds`: half a minute after the thing somebody is being told about, by which time the
-footage is rolling out of the buffer the clip is cut from.
+episode is still open** — above the early return that skips storage. Waiting for the close would
+delay the queue by `AbsenceSeconds`: half a minute after the thing somebody is being told about, by
+which time the footage is rolling out of the buffer the clip is cut from.
+
+Whether an episode is an alert is settled in two halves, and only one of them at the open. Whether it
+*may* be one — an arrival, of a class in `AlertClasses` — is decided there and never revisited.
+Whether it was ever seen clearly enough is asked again on every measured frame until it passes, then
+never again. So an alert can be raised several seconds into a sighting, which is the point: the frame
+an episode opens on is the one where a subject is furthest away and least certain, and judging them
+there made examining them early a penalty. See the alert rule in
+[detection.md](detection.md#the-alert-rule).
 
 That path runs once a frame for as long as the object is in view, which is why the alert's `_id` is
 the episode's: all but the first insert are a duplicate key, and
 [`AlertRepository.RaiseAsync`](../Server/Serval.Server/Alerts/AlertRepository.cs) reports which one
-it was so only the first queues a clip.
+it was so only the first queues a clip. An episode continued past `MaxEpisodeSeconds` carries a new
+id and so raises its own alert, which is intended — a presence long enough to be cut in half is
+reported as two records, and both are true.
 
 The consequence to keep in mind: `peak_at` and `box` are the best frame **so far** rather than the
 best of the whole episode. That is the right picture anyway — the card says "the frame it fired on".

--- a/Docs/coral.md
+++ b/Docs/coral.md
@@ -447,8 +447,8 @@ turn them off. Moving a 6-camera site from a 320 to a 512 input:
 | Camera | at 320 | at 512 |
 |---|---|---|
 | 1536x432 (32:9) | 0.21x, tiled into 12 | **0.33x, tiled into 4** |
-| 640x360 (16:9) | 0.50x, tiled into 6 | **0.80x, crops off, one whole-frame pass** |
-| 480x640 (3:4) | 0.50x, tiled into 6 | **0.80x, crops off, one whole-frame pass** |
+| 640x360 (16:9) | 0.50x, tiled into 6 | **0.80x, crops off; 2 tiles run whole with `TiledFloor`** |
+| 480x640 (3:4) | 0.50x, tiled into 6 | **0.80x, crops off; 2 tiles run whole with `TiledFloor`** |
 
 Reserved tile work fell from about 12/s to about 3/s at `DetectFps=2`, and the picture each camera is
 shown improved at the same time. **The catch:** with crops off, a whole-frame pass runs *every* frame
@@ -486,22 +486,59 @@ a fraction of a millisecond against tens for the inference, so measure before tr
 ## Input shape, and what tiling is for
 
 An EdgeTPU graph is compiled for **one** shape, so every camera shares it — the per-camera rectangular
-shapes the ONNX path uses cannot carry over. At 320×320 a 16:9 stream arrives at half scale and a 32:9
-panoramic at a fifth.
+shapes the ONNX path uses cannot carry over. And the shape is square, where cameras are not: at 320×320 a
+16:9 stream arrives at half scale and a 32:9 panoramic at a fifth.
 
-Region cropping helps by itself and needs no configuration: `RegionMode.Auto` turns on at a gain of 1.5,
-and a small input satisfies that comfortably. What it does not cover is the **floor pass** — the
-whole-frame look that guarantees acquisition of something that arrived while motion was blind. That pass
-covers every pixel at a scale which has already discarded the far field, so covering is not examining.
+**How much a small input buys depends on the input, and 512 is the awkward one.** At 320² a 640×360
+stream is squeezed to half, a 2.0x gain that `Regions:Mode = auto` takes without hesitation. At 512² the
+same stream arrives at 0.80x — a gain of only 1.25, and 56 % of the model's field is grey padding.
 
-`Regions:TiledFloor` replaces it with a rolling sweep of native-scale tiles, one tile per frame so the
-guaranteed cost stays flat. **Off by default and independent of `Regions:Mode`**, because it changes how
-the coverage guarantee itself is made and must not arrive as a side effect of anything else.
+**Cropping is the wrong tool for that 1.25x.** With `Regions:MaxRegionScale` holding a crop to native
+scale, the smallest crop such a camera can cut is the detector's own input — a 512×360 window out of a
+640×360 frame, four fifths of the picture. Turning crops on also moves the whole-frame pass from every
+frame to once per `Regions:FloorSeconds`. That trades the acquisition guarantee for a close-up which is
+not one, which is why `Regions:AutoMinRatio` is 1.5 and must not be lowered to admit these cameras.
 
-**It is a standing cost on a wide camera, not an occasional one.** A 1536×432 frame needs 12 tiles at a
-320 input, which is 6 seconds at 2 fps — longer than the default 5 s `FloorSeconds`, so that camera's
-sweeps run back-to-back at one reserved inference per frame. That is the honest reading of the guarantee,
-and it is why this wants an accelerator behind it rather than four CPU cores.
+The 512×360 window is still the right *picture*: measured on a living-room camera with a cat in plain
+view, over 92 frames, it took animal detections from 4 frames to 15 and produced the first cat
+detections that camera had registered. `Regions:TiledFloor` delivers it without touching the schedule.
+
+What cropping does not cover is the **floor pass** — the whole-frame look that guarantees acquisition of
+something that arrived while motion was blind. That pass covers every pixel at a scale which has already
+discarded the far field, so covering is not examining.
+
+`Regions:TiledFloor` replaces it with a sweep of native-scale tiles. **Off by default**, because it
+changes how the coverage guarantee itself is made and must not arrive as a side effect of anything else.
+`Regions:TiledFloorMinGain` is 1.2 — read it as "does tiling buy any scale at all", not as a cost guard,
+because tile count *grows* with the squeeze and so a minimum-gain threshold admits the expensive cameras.
+
+**The sweep runs on one of two schedules, and they make different promises.**
+
+A sweep of at most `Regions:SweepAtOnce` tiles — 2 by default, which is what a 16:9 camera costs against
+a square input — is run **whole, on every frame**. Every pixel is then examined exactly as often as under
+the single shrunken pass it replaces, at native scale instead. That is a strict improvement, it needs
+nothing alongside it, and it is what the 640×360 and 480×640 cameras get.
+
+A longer sweep is spread **one tile per frame**, restarting every `Regions:FloorSeconds`, so the
+guaranteed cost stays at one inference per frame. This one **needs `Regions:Mode` on alongside it, and
+the planner enforces that**: it examines a given pixel once per cycle, and `ObjectTracker` drops a
+tentative track the moment one frame passes without matching it, so a new object seen that rarely never
+confirms and never becomes an episode. Cropping is what bridges the gap — a retention crop is planned for
+every *live* track, tentative ones included, and re-sights the subject on the frames the sweep is looking
+elsewhere. The panoramic runs this way.
+
+Because a sweep run whole examines overlapping tiles in the same frame, one object is found once per tile
+it falls in; `OverlappingRegions.Fold` reduces those to the best copy before the tracker sees them, since
+the tracker's own answer to a second copy is a second track.
+
+**Cost is very different at the two ends, and the tile geometry is why.** A 1536×432 frame needs 12
+tiles at a 320 input — 6 seconds at 2 fps, longer than the default 5 s `FloorSeconds`, so that camera's
+sweeps run back-to-back at one reserved inference per frame. A 640×360 frame at 512² needs **two**, and
+because the last tile sits flush to the far edge they are 512-wide tiles at x=0 and x=128, overlapping by
+384 px. Run whole, that is two reserved inferences per frame instead of one — the only place in this
+design where the guarantee gets more expensive, and the reason `SweepAtOnce` is a setting rather than a
+constant. At `DetectFps=2` it is 4/s per camera; check it against the `Detection budget` line, which
+reports what the host was measured at.
 
 `Regions:TileOverlapFraction` is not a tuning nicety: an object lying across a tile boundary is cut in
 two and detected as neither half. It has to exceed the largest thing worth finding as a share of a tile.

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -350,6 +350,10 @@ pays for a deployment that also crops. If distant subjects are being missed, rai
 detect stream *and* leave `Detection:Regions:Mode` at `auto`; raising either alone does nothing. The
 measurements behind that are in [detection.md](detection.md#what-this-is-actually-worth-measured).
 
+Raising the stream also raises the *honest* magnification available, which is what a crop can actually
+deliver: `Detection:Regions:MaxRegionScale` holds a crop at native scale, so the ceiling on a crop's
+magnification is exactly the frame-to-input gain, and a bigger stream is the only thing that moves it.
+
 `Ingest:DetectFrameDir` (default `/dev/shm/serval/detect`) is where they are staged, and **it must be
 tmpfs**. Frames are written and deleted within milliseconds; on a real filesystem that is continuous
 churn on the device holding the recordings, for no benefit. Both compose files mount it; the Server

--- a/Docs/detection.md
+++ b/Docs/detection.md
@@ -106,7 +106,13 @@ and it is about recall, not speed.**
 
 So on each frame `RegionPlanner` builds a short list of places to look:
 
-1. **The floor** — the whole frame, every `Regions:FloorSeconds`, unconditionally.
+1. **The floor** — the whole frame. **How often depends on whether crops are on, and this is the
+   single most consequential thing in the planner.** With crops off it is *every frame*; with them on
+   it drops to once every `Regions:FloorSeconds`, and motion and track crops carry the time in
+   between. Where `Regions:TiledFloor` is on and the camera is squeezed enough to earn it, the pass
+   becomes a native-scale sweep: run whole on every frame if it is at most `Regions:SweepAtOnce`
+   tiles, otherwise one tile per frame on the `FloorSeconds` interval. See
+   [the tiled floor](#a-region-has-a-ceiling-a-floor-and-a-magnification-limit) and `coral.md`.
 2. **Tracks** — a crop around each live track's predicted position, whether or not anything moved
    there, so something already known about keeps being seen after it stops moving.
 3. **Motion** — a crop around each cluster of changed cells, at native resolution, capped by
@@ -128,6 +134,29 @@ whole-frame change is correctly rejected as *not* movement) and has not moved si
 proposes nothing returns nothing, and the policy is not told — an observation nobody made must not
 close an episode.
 
+#### The floor has to be able to confirm a track on its own
+
+The rule that ties the planner to the tracker, and the one that is easiest to break without noticing:
+**a subject must be examined on enough *consecutive* frames for a track to confirm.** `ObjectTracker`
+drops a tentative track the moment one frame passes without matching it, and will not confirm before
+`Tracking:ConfirmSeconds` — 1.0 s, so three consecutive frames at 2 fps. A schedule that looks
+somewhere else in between produces no episodes at all, however good each individual look was.
+
+That divides floors into two kinds, and it is worth knowing which one a camera has:
+
+| Floor | What a still subject waits | Acquires on its own? |
+|---|---|---|
+| Whole frame every frame (crops off) | `ConfirmSeconds` | Yes |
+| Sweep of at most `SweepAtOnce` tiles, run whole every frame | `ConfirmSeconds` | Yes |
+| Whole frame every `FloorSeconds` (crops on) | up to `FloorSeconds` + `ConfirmSeconds` | Only with motion crops alongside |
+| Sweep spread one tile per frame | up to `FloorSeconds` + the sweep | Only with motion crops alongside |
+
+The bottom two are not defects — they are the trade a camera makes when a crop is genuinely a close-up.
+They become one when a camera is moved into them for no gain, which is what `AutoMinRatio` at 1.5 and
+`SweepAtOnce` at 2 prevent. `AcquisitionTests` asserts the budgets in that table by driving the real
+planner against the real tracker: this is a property of the two together, and each is correct alone
+while the pair detects nothing.
+
 **Crops only pay when frames are much larger than the model's input**, and the governing number is
 just the ratio of the two:
 
@@ -135,8 +164,22 @@ just the ratio of the two:
 |---|---|---|---|
 | 1080p | 320² | ~3.4x | clearly worth it |
 | 720p | 320² | ~2.25x | worth it |
-| 1080p | 640² | ~1.7x | marginal |
+| 1080p | 640² | ~1.7x | worth it |
+| 640x360 | 512² (a compiled accelerator graph) | 1.25x | not worth it — see below |
 | 720p | 640² | ~1.1x | pointless |
+
+`Regions:AutoMinRatio` is where that verdict is drawn, at 1.5x. **The gain is the whole of what a crop
+can honestly deliver**, because `Regions:MaxRegionScale` holds a crop's scale at 1.0 —
+see [the magnification limit](#and-a-magnification-limit-which-is-the-one-that-bites).
+
+**Why the 1.25x row is declined, which is not obvious.** Two things follow from holding a crop to native
+scale. The smallest crop on such a camera is the detector's own input — 512x360 out of a 640x360 frame,
+four fifths of the picture, which is not a close-up. And turning crops on moves the whole-frame pass
+from every frame to once per `FloorSeconds`. Spending the acquisition guarantee on that is a straight
+loss, measured as one: on a real fleet it took a driveway's episode count to zero.
+
+Such a camera wants native scale *without* the schedule change, which is `Regions:TiledFloor` —
+it replaces the whole-frame pass rather than thinning it.
 
 #### What this is actually worth, measured
 
@@ -231,10 +274,27 @@ too, so growing the slack axis to that ratio lands at most on the bound's own va
 crop inside the bound cannot be shaped out of it. Shaping happens before any oversized region is cut,
 since a piece is already the bound's shape and it is the region it came from that decides coverage.
 
-### A region has a ceiling as well as a floor
+**And it cannot breach the magnification limit either**, for the simpler reason that shaping only ever
+grows: a crop already at or above the limit's floor stays there. The floor is applied first, in the same
+`Fit` that grows a crop to `MinSizeFraction`, so a track crop and a motion crop of the same subject are
+bounded identically — which is the invariant `Fit` exists for.
 
-`Regions:MinSizeFraction` stops a crop being too tight to recognise anything in.
-`Regions:MinRegionScale` stops one being so large that it has to be shrunk past the point where the
+### A region has a ceiling, a floor, and a magnification limit
+
+Three guards, in two different units, answering three different questions. Confusing them is easy and
+the units are why:
+
+| Guard | Default | Units | Stops |
+|---|---|---|---|
+| `Regions:MinSizeFraction` | 0.25 | fraction of the frame | a crop too tight to hold the object *and its surroundings* |
+| `Regions:MaxRegionScale` | 1.0 | scale against the input | a crop being **enlarged** — resolution that is not there |
+| `Regions:MinRegionScale` | 0.5 | scale against the input | a crop so large it is shrunk past where the model invents things |
+
+`MinSizeFraction` and `MinRegionScale` are *not* a pair, despite reading like one. The first is a share
+of the frame and cannot express "too tight for this detector"; the pair in the same units is
+`MaxRegionScale` and `MinRegionScale`, which bracket the scale a region may reach the input at.
+
+`Regions:MinRegionScale` stops a region being so large that it has to be shrunk past the point where the
 detector is reliable. Below that point a small model does not merely miss things — it invents them.
 
 Tested on an SSD MobileDet at 320² on an Edge TPU, against a static garden ornament on a 1536x432
@@ -269,6 +329,70 @@ the hard case and wants 0.75; a dynamic-shape ONNX export on the same camera doe
 six frames put 0.5, 0.6 and 0.66 all in the failing range, and the counts are not monotonic between
 them. Anything derived from this needs a batch of frames across the day's light rather than a fixture,
 and the same is true of any future model swap measured the same way.
+
+#### And a magnification limit, which is the one that bites
+
+The ceiling above is about crops that are too *large*. The limit below is about crops that are too
+*small*, and it reaches far more cameras — because a crop smaller than the detector's input has to be
+enlarged to fill it, and enlarging is interpolation. It adds pixels, not detail.
+
+Measured on a 640x360 sub stream, a car found in **all sixty of sixty** whole frames at 0.906 mean
+confidence, varying nothing but how tightly the crop around it was taken:
+
+| `MinSizeFraction` | Crop scale | Found again | Mean confidence |
+|---|---|---|---|
+| whole frame | 1.00x | 60 of 60 | 0.906 |
+| 0.80 | **1.25x** | 60 of 60 | **0.918** |
+| 0.75 | 1.33x | 60 of 60 | 0.862 |
+| 0.70 | 1.43x | 59 of 60 | 0.710 |
+| 0.65 | 1.54x | 59 of 60 | 0.680 |
+| 0.60 | 1.67x | 59 of 60 | 0.649 |
+| 0.50 | 2.00x | 27 of 60 | 0.420 |
+| **0.25** | **2.75x** | **none** | — |
+
+Monotonic, and past about 1.25x every crop is worse than not cropping at all. The gentlest one is the
+only one that beats the whole frame, and it does that by trimming letterbox padding rather than by
+magnifying.
+
+**Why `MinSizeFraction` cannot express this.** It is a share of the frame, so what it means in scale
+depends on the camera:
+
+```
+crop scale = 1 / (Gain x MinSizeFraction)
+```
+
+At the default that is `4 / Gain` — so the smallest crop is *enlarged* on every camera under 4x gain,
+which is nearly all of them. `Mode = Auto` admits from 1.5x upward, so most of the admitted range was
+inside the enlarging band. Note the closed form assumes the crop is not clamped to the frame; where it
+is, the real figure is gentler, which is why the 640x360 measurement above shows 2.75x where the
+formula says 4.0.
+
+`Regions:MaxRegionScale` states the guard where it belongs, against the input:
+
+- **1.0, the default** — a crop is never enlarged, only ever shrunk.
+- It **costs no magnification that was ever real.** A crop's magnification over the whole-frame pass is
+  its scale divided by the whole frame's fit, so holding scale at 1.0 leaves the maximum at exactly
+  `Gain`: all of the detail the camera has over the input, and none of the invented kind.
+- It **clamps to the frame**, and usually holds anyway. A 512x512 floor on a 640x360 frame gives
+  512x360, which still reaches a 512x512 input at 1.00x — because a region's scale is the *minimum*
+  over its two axes, so clamping the slack one costs nothing.
+- The one case it cannot honour is a frame smaller than the input on **both** axes: the whole picture
+  is already being enlarged before any crop is cut. The per-camera startup line says so in as many
+  words, because it means the deployment has given that camera a larger input than it has pixels for.
+
+What it changes, per camera:
+
+| Frame → input | Gain | Crop before | Scale | Crop after | Scale |
+|---|---|---|---|---|---|
+| 1536x432 → 512² | 3.0 | 384x384 | 1.33x | **512x432** | **1.00x** |
+| 1920x1080 → 640x384 | 3.0 | 480x288 | 1.33x | **640x384** | **1.00x** |
+| 640x360 → 512² | 1.25 | 160x160 | 3.20x | **512x360** | **1.00x** |
+| 3840x2160 → 640x384 | 6.0 | 960x576 | 0.67x | 960x576 | **unchanged** |
+
+The 4K row is the compatibility guarantee: where `MinSizeFraction` already floors the crop above the
+input, the limit has nothing to add. It is also where the remaining headroom is — that camera has 6x of
+real detail and takes 4x, so `MinSizeFraction` is what caps it now. Lowering that is safe under the
+limit and wants its own measurement.
 
 **What went wrong without it was a runaway, not a near miss.** A union is itself a region, so unions
 chain: three subjects spread across a wide frame are enough, because the first union reaches far
@@ -398,9 +522,30 @@ and obvious in the database.
 
 `AlertClasses` is what the alert queue is filled from: an episode that passes all three conjuncts
 becomes a row on the Alerts screen with a preview clip cut around it. See
-[alerts.md](alerts.md) — including the part that matters here, which is that an alert is raised when
-the episode **opens** rather than when it closes, so `AlertClasses` and `AlertMinConfidence` decide
+[alerts.md](alerts.md) — including the part that matters here, which is that an alert is raised while
+the episode is **open** rather than when it closes, so `AlertClasses` and `AlertMinConfidence` decide
 something a person sees within seconds rather than after `AbsenceSeconds`.
+
+#### The alert rule
+
+> An **arrival** of a class in `AlertClasses`, which at any point during its episode is seen with
+> confidence at or above `AlertMinConfidence`, raises **exactly one alert for that episode**.
+
+- **Arrival only.** Presence is not news — the scenery a camera opened on, and a thing that came back
+  to where it just left, are both already known about. `NoveltySeconds` is what draws that line.
+- **Ever, not first.** The confidence test is re-asked on every measured frame until it passes, then
+  never again. Judging only the opening frame would penalise examining a subject early: the first look
+  at someone walking up a path is the one where they are furthest away and smallest, so a real visitor
+  can open below the threshold and be well above it seconds later.
+- **Once per episode.** Repeated raises inside one episode collapse — `AlertService` is idempotent on
+  the episode id. An episode continued past `MaxEpisodeSeconds` is a *new* episode and may raise its
+  own alert; eligibility is carried across that cut so a presence not yet seen clearly enough can
+  still earn one afterwards.
+
+The flag is one-way: a record that stopped being an alert after somebody read it would be worse than
+one that never claimed to be, and there is no matching harm in one that earns the claim a second late.
+A consequence worth knowing when reading records is that an alert's `BestBox` score is always at or
+above the threshold it fired on, so the number shown and the number judged agree.
 
 ### Masks
 

--- a/Server/Serval.Server.Tests/CameraAiSignatureTests.cs
+++ b/Server/Serval.Server.Tests/CameraAiSignatureTests.cs
@@ -353,6 +353,7 @@ public class CameraAiSignatureTests
         data.Add(r => r.PaddingFraction = 0.2);
         data.Add(r => r.MinSizeFraction = 0.5);
         data.Add(r => r.MinRegionScale = 0.75);
+        data.Add(r => r.MaxRegionScale = 1.5);
 
         // The tiling knobs are read when the pipeline plans its floor tiles on the first frame,
         // so they are session-read like everything else here. The hand-written digest this
@@ -360,6 +361,7 @@ public class CameraAiSignatureTests
         // exists to prevent.
         data.Add(r => r.TiledFloor = !r.TiledFloor);
         data.Add(r => r.TiledFloorMinGain = 3.5);
+        data.Add(r => r.SweepAtOnce = 4);
         data.Add(r => r.TileOverlapFraction = 0.33);
         return data;
     }

--- a/Server/Serval.Server/Ai/CameraVisionPipeline.cs
+++ b/Server/Serval.Server/Ai/CameraVisionPipeline.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using Serval.Ai;
 using Serval.Contracts;
 using Serval.Server.Cameras;
@@ -74,6 +75,11 @@ public sealed class CameraVisionPipeline : IDisposable
     /// <summary>The largest crop this camera may examine, or null when nothing bounds them. Resolved
     /// once alongside <see cref="_floorTiles"/> and constant for the same reason.</summary>
     private (int Width, int Height)? _maxRegion;
+
+    /// <summary>The smallest crop this camera may examine — the size below which reaching the detector
+    /// would mean enlarging it — or null when magnification is unbounded. Resolved and constant for the
+    /// reason <see cref="_maxRegion"/> is.</summary>
+    private (int Width, int Height)? _minRegion;
 
     /// <summary>The shape this camera's frames and crops are prepared to, resolved once
     /// <see cref="_prepared"/> exists and constant for as long as it does.</summary>
@@ -286,6 +292,7 @@ public sealed class CameraVisionPipeline : IDisposable
             }
 
             _maxRegion = _ai.Detection.Regions.MaxRegion(_input);
+            _minRegion = _ai.Detection.Regions.MinRegion(_input);
 
             // Said out loud because every part of it is a silent decision otherwise: `auto` resolving
             // crops to off leaves no trace, and a camera whose aspect found no good shape looks
@@ -300,22 +307,77 @@ public sealed class CameraVisionPipeline : IDisposable
             // The floor's own form is said out loud for the same reason the crop decision is: whether the
             // whole-frame pass is one shrunken look or a sweep of native-scale tiles is invisible
             // otherwise, and it is the difference between covering the frame and examining it.
-            string floor = _floorTiles is { Count: > 1 } tiles
-                ? $"tiled into {tiles.Count}"
-                : "one whole-frame pass";
+            // The tile's own geometry goes in beside the whole frame's, because the two picture figures
+            // next to each other are the whole argument for sweeping: a tile is the detector's shape
+            // clamped to the frame, so it arrives at native scale with the padding the shrunken look pays.
+            string floor;
+            if (_floorTiles is { Count: > 1 } tiles)
+            {
+                FrameRegion tile = tiles[0];
+                double tileFit = Math.Min(
+                    (double)_input.Width / tile.Width, (double)_input.Height / tile.Height);
+                double tilePicture =
+                    Math.Round(tile.Width * tileFit) * Math.Round(tile.Height * tileFit)
+                    / ((double)_input.Width * _input.Height);
+
+                // Stated as a cadence rather than left to be inferred from the tile count, because
+                // how often the sweep completes is what decides whether anything can be acquired at
+                // all: run whole it covers the frame every frame, spread it covers the frame once per
+                // FloorSeconds and only motion and tracks look in between.
+                string cadence = tiles.Count <= _ai.Detection.Regions.SweepAtOnce
+                    ? "all of them every frame"
+                    : string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"one per frame, the whole frame every {_ai.Detection.Regions.FloorSeconds:0.#} s");
+
+                // Formatted the way the whole frame's own figures are, so the two percentages sit
+                // side by side and can be compared without a second glance.
+                floor = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"tiled into {tiles.Count} {tile.Width}x{tile.Height} tiles — "
+                    + $"{tilePicture:P0} picture at {tileFit:0.00}x, {cadence}");
+            }
+            else
+            {
+                floor = "one whole-frame pass";
+            }
 
             // The bound is reported as what it does to this camera rather than as the setting, because
             // the setting is a scale and the consequence is a size: on a frame that already fits inside
             // it nothing is ever cut, and saying "0.5" would leave an operator unable to tell which of
             // their cameras it touches.
             string bound = _maxRegion is { } max && (frame.Width > max.Width || frame.Height > max.Height)
-                ? $"crops bounded to {max.Width}x{max.Height}"
-                : "no crop is large enough to bound";
+                ? $"Crops bounded to {max.Width}x{max.Height}"
+                : "No crop is large enough to bound";
+
+            // The magnification limit, reported as the size it produces for the same reason the ceiling
+            // is. The third case is worth naming: a frame smaller than the input on both axes is already
+            // being enlarged before any crop is cut, so the limit cannot be honoured and this camera has
+            // been given a bigger input than it has pixels for.
+            string limit;
+            if (_minRegion is not { } min)
+            {
+                limit = "Crops have no magnification limit";
+            }
+            else
+            {
+                int floorWidth = Math.Min(frame.Width, min.Width);
+                int floorHeight = Math.Min(frame.Height, min.Height);
+                double limitScale = Math.Min(
+                    (double)_input.Width / floorWidth, (double)_input.Height / floorHeight);
+
+                limit = limitScale > _ai.Detection.Regions.MaxRegionScale
+                    ? $"The whole frame is already magnified {limitScale:0.00}x, so no crop here "
+                        + $"can hold to {_ai.Detection.Regions.MaxRegionScale:0.00}x"
+                    : $"Crops never smaller than {floorWidth}x{floorHeight}, so none is magnified "
+                        + $"past {limitScale:0.00}x";
+            }
 
             _logger.LogInformation(
                 "Camera {CameraId}: {Frame}x{FrameHeight} frames into a {Input}x{InputHeight} input "
                 + "— {Picture:P0} picture at {Fit:0.00}x scale. Region crops {State}, a "
-                + "{Gain:0.0}x gain on a distant subject (mode {Mode}). Floor: {Floor}. {Bound}.",
+                + "{Gain:0.0}x gain on a distant subject (mode {Mode}). Floor: {Floor}. {Bound}. "
+                + "{Limit}.",
                 _camera.Id,
                 frame.Width,
                 frame.Height,
@@ -327,7 +389,8 @@ public sealed class CameraVisionPipeline : IDisposable
                 RegionOptions.Gain(frame.Width, frame.Height, _input),
                 _ai.Detection.Regions.Mode,
                 floor,
-                bound);
+                bound,
+                limit);
         }
 
         // Motion is scored only when crops are being cut, because proposing where to cut them is the
@@ -360,7 +423,8 @@ public sealed class CameraVisionPipeline : IDisposable
             [.. _tracker!.Live],
             _floorTiles,
             _maxRegion,
-            (double)_input.Width / _input.Height);
+            (double)_input.Width / _input.Height,
+            _minRegion);
 
         if (planned.Count == 0)
         {
@@ -413,7 +477,10 @@ public sealed class CameraVisionPipeline : IDisposable
             }
         }
 
-        return found;
+        // Regions in one frame are allowed to overlap, so one object can be found once per region it
+        // falls in. Folded before the tracker rather than after, because the tracker's own answer to a
+        // second copy is a second track.
+        return admitted.Count > 1 ? OverlappingRegions.Fold(found) : found;
     }
 
     private IReadOnlyList<ObjectEpisode> Compare(Snapshot snapshot)

--- a/Server/Serval.Server/Configuration/SettingsCatalog.cs
+++ b/Server/Serval.Server/Configuration/SettingsCatalog.cs
@@ -550,20 +550,40 @@ public static class SettingsCatalog
             + "in the log.",
             SettingKind.Choice, Choices: ["auto", "on", "off"]),
 
+        new("Serval:Ai:Detection:Regions:AutoMinRatio", GroupAi, "Zoom in when a crop would be at least",
+            "What 'auto' above decides on: how much bigger a subject arrives in a close-up than in the "
+            + "whole picture shrunk to fit the model. Lowering it does more than add close-ups — once "
+            + "they are on, the whole picture is checked every few seconds instead of every frame. On a "
+            + "camera with little to recover that buys close-ups which are nearly the whole picture "
+            + "anyway, so below about 1.5 it costs more than it finds.",
+            SettingKind.Number, Min: 1, Max: 8, Unit: "x", Advanced: true),
+
         new("Serval:Ai:Detection:Regions:TiledFloor", GroupAi,
             "Check the picture in overlapping squares",
             "How the guaranteed whole-frame look is made. Off, it is one pass with the frame shrunk to "
             + "fit the model — which covers every pixel but, on a wide camera squeezed hard, at a scale "
-            + "that has already lost the far field. On, it sweeps native-scale tiles instead, one per "
-            + "frame. Costs several inferences where the shrunken look costs one, so it wants an "
-            + "accelerator behind it. Only engages on cameras squeezed past the threshold below.",
+            + "that has already lost the far field. On, it checks native-scale tiles instead. A short "
+            + "sweep is checked all at once every frame; a longer one takes a tile at a time, and that "
+            + "one also needs zooming in on movement, because it looks at the edges of the picture only "
+            + "once a pass and a new object seen that rarely is never confirmed. Only engages on "
+            + "cameras squeezed past the threshold below.",
             SettingKind.Bool, RestartRequired: true, Advanced: true),
 
         new("Serval:Ai:Detection:Regions:TiledFloorMinGain", GroupAi, "Tile the floor above",
             "How much the frame has to be shrunk before tiling is worth it, as the same magnification "
             + "ratio that decides cropping. A camera already arriving near full scale gains nothing "
-            + "from tiles and would pay several inferences for it.",
+            + "from tiles. Note this asks whether tiling buys anything, not what it costs: a camera "
+            + "squeezed harder needs more tiles, so a low threshold admits the cheap cameras rather "
+            + "than the expensive ones.",
             SettingKind.Number, RestartRequired: true, Min: 1, Max: 10, Unit: "x", Advanced: true),
+
+        new("Serval:Ai:Detection:Regions:SweepAtOnce", GroupAi, "Examine a whole sweep in one frame up to",
+            "A short sweep is checked all at once, every frame, covering the picture exactly as often "
+            + "as the single shrunken look it replaces and in full detail. A longer one goes a tile at "
+            + "a time, covering the picture only once every few seconds and leaning on movement in "
+            + "between. Two tiles is what an ordinary 16:9 camera costs; raising this multiplies the "
+            + "guaranteed work every affected camera does, so check the detection budget afterwards.",
+            SettingKind.Number, Min: 1, Max: 8, Unit: "tiles", Advanced: true),
 
         new("Serval:Ai:Detection:Regions:TileOverlapFraction", GroupAi, "Tile overlap",
             "How much neighbouring tiles share. Not a nicety: an object lying across a tile boundary is "
@@ -603,6 +623,17 @@ public static class SettingsCatalog
             + "scale and called a person below it, more confidently the further it shrank. A crop "
             + "bigger than this is examined in overlapping pieces instead. Zero switches it off.",
             SettingKind.Number, Min: 0, Max: 1, Advanced: true),
+
+        new("Serval:Ai:Detection:Regions:MaxRegionScale", GroupAi, "Never magnify a crop past",
+            "A crop smaller than the model's input has to be blown up to fill it, and blowing a picture "
+            + "up does not add detail — it invents it. Measured against a car found in all sixty of "
+            + "sixty whole frames: at 1.25x it was still found in all sixty, at 2x in twenty-seven, and "
+            + "at 2.75x — what the smallest crop above asks for on an ordinary camera — in none at all. "
+            + "1 means a crop is never enlarged, only ever shrunk, and costs no magnification that was "
+            + "ever real. A camera whose pictures are smaller than the model's input cannot honour this, "
+            + "because the whole picture is already being enlarged before any crop is cut. Zero switches "
+            + "it off.",
+            SettingKind.Number, Min: 0, Max: 4, Unit: "x", Advanced: true),
 
         // ---- Following objects between frames ----------------------------------------------------
         new("Serval:Ai:Detection:Tracking:ConfirmSeconds", GroupObjects, "Believe it after",
@@ -694,7 +725,10 @@ public static class SettingsCatalog
 
         new("Serval:Ai:Detection:AlertMinConfidence", GroupObjects, "How sure it must be to alert",
             "Deliberately higher than the ordinary floor. A false record costs a row in a feed; a "
-            + "false alert costs trust in every alert after it.",
+            + "false alert costs trust in every alert after it. Something that turns up raises one "
+            + "alert as soon as it is seen this clearly, at whatever point in the sighting that "
+            + "happens — a visitor walking up a path is smallest and least certain in the moment they "
+            + "first appear.",
             SettingKind.Number, Min: 0, Max: 1),
 
         new("Serval:Ai:Detection:AbsenceSeconds", GroupObjects, "Consider it gone after",

--- a/Server/Serval.Server/Dockerfile
+++ b/Server/Serval.Server/Dockerfile
@@ -81,6 +81,13 @@ ARG LLAMA_BACKEND=Vulkan
 ARG SERVAL_VERSION=""
 ARG SOURCE_REVISION=""
 
+# The solution-wide properties every project inherits: the version block, and the Product / Company /
+# Copyright / license / repository metadata that becomes assembly attributes. MSBuild finds it by
+# walking up from each project, so it has to sit at /src, and it has to be here for the restore as
+# well as the publish — both evaluate it. Its own layer because it changes far less often than the
+# csproj files below.
+COPY Directory.Build.props .
+
 # Restore first with only the csproj files present, so the (slow) restore layer stays cached
 # until a dependency actually changes rather than on every source edit.
 COPY Server/Serval.Server/Serval.Server.csproj Server/Serval.Server/
@@ -91,9 +98,17 @@ RUN dotnet restore Server/Serval.Server/Serval.Server.csproj -p:LlamaBackend=$LL
 
 COPY Server/Serval.Server/ Server/Serval.Server/
 COPY Shared/ Shared/
+
+# ${VAR:+...} so an empty build arg passes no property at all rather than an empty one. The two are
+# not the same: -p: sets a *global* property, which a project cannot override, so the
+# `Condition="'$(VersionPrefix)' == ''"` fallback to 0.0.0 in Directory.Build.props evaluates true and
+# is then discarded, and Version comes out as a bare `-dev`. Neither error names the property or the
+# file: in this stage it is MSB4044 about a missing NuGetVersion, outside it "'-dev' is not a valid
+# version string".
 RUN dotnet publish Server/Serval.Server/Serval.Server.csproj \
         -c Release -o /app --no-restore -p:LlamaBackend=$LLAMA_BACKEND \
-        -p:VersionPrefix=$SERVAL_VERSION -p:SourceRevisionId=$SOURCE_REVISION
+        ${SERVAL_VERSION:+-p:VersionPrefix=$SERVAL_VERSION} \
+        ${SOURCE_REVISION:+-p:SourceRevisionId=$SOURCE_REVISION}
 
 # ---- Edge TPU natives ----
 #

--- a/Shared/Serval.Ai.Core/AiOptions.cs
+++ b/Shared/Serval.Ai.Core/AiOptions.cs
@@ -569,18 +569,41 @@ public sealed record RegionOptions
     /// </summary>
     public RegionMode Mode { get; set; } = RegionMode.Auto;
 
-    /// <summary>The ratio at or above which <see cref="RegionMode.Auto"/> turns regions on.</summary>
+    /// <summary>
+    /// The ratio at or above which <see cref="RegionMode.Auto"/> turns regions on.
+    ///
+    /// <para><b>This decides how often the whole picture is examined, not only where to look.</b> With
+    /// crops off, <see cref="RegionPlanner"/> examines the entire frame on <em>every</em> frame; with
+    /// them on, the whole frame drops to once per <see cref="FloorSeconds"/> and motion and tracks carry
+    /// the time in between. The trade only pays when a crop is much smaller than the frame.</para>
+    ///
+    /// <para>1.5 is where that stops being true. <see cref="MaxRegionScale"/> holds a crop to native
+    /// scale, so at a gain of 1.25 the smallest crop is the detector's own input — 512x360 out of a
+    /// 640x360 frame, four fifths of the picture. Lowering this below 1.5 spends the every-frame
+    /// guarantee on close-ups that are not close-ups, and costs acquisition outright.</para>
+    ///
+    /// <para>A camera squeezed hard enough for tiles gets its native scale from
+    /// <see cref="TiledFloor"/> instead, which replaces the whole-frame pass rather than thinning it.</para>
+    /// </summary>
     public double AutoMinRatio { get; set; } = 1.5;
 
     /// <summary>
     /// Whether the whole-frame pass is made as a sweep of native-scale tiles instead of one shrunken
     /// look.
     ///
-    /// <para><b>Off by default, and independent of <see cref="Mode"/> on purpose.</b> Region cropping
-    /// decides where to look *opportunistically*; this changes how the coverage guarantee itself is
-    /// made, which is a much bigger behavioural change and not one that should arrive as a side effect
-    /// of anything. A working deployment must be able to take an accelerator's code without its
-    /// detection behaviour moving.</para>
+    /// <para><b>Off by default,</b> because it changes how the coverage guarantee itself is made — a
+    /// much bigger behavioural change than deciding where to look opportunistically, and not one that
+    /// should arrive as a side effect of anything else.</para>
+    ///
+    /// <para><b>A sweep of at most <see cref="SweepAtOnce"/> tiles is run whole, on every frame.</b>
+    /// Every pixel is then examined as often as under the single shrunken pass it replaces, at native
+    /// scale instead, and it needs nothing alongside it.</para>
+    ///
+    /// <para><b>A longer sweep is spread one tile per frame, and needs <see cref="Mode"/> on;
+    /// <see cref="RegionPlanner"/> enforces that.</b> It examines a given pixel once per cycle, and
+    /// <see cref="ObjectTracker"/> drops a tentative track the moment one frame passes without matching
+    /// it, so a subject seen that rarely never confirms and never becomes an episode. Retention crops
+    /// bridge it: one is planned for every *live* track, tentative ones included.</para>
     ///
     /// <para><b>What it is for.</b> A backend with one compiled input shape gives every camera the same
     /// one, so a 32:9 panoramic is squeezed to a fraction of its scale — the floor covers every pixel at
@@ -598,11 +621,33 @@ public sealed record RegionOptions
     /// How badly the whole frame has to be shrunk before <see cref="TiledFloor"/> actually tiles.
     ///
     /// The same <see cref="Gain"/> ratio <see cref="RegionMode.Auto"/> uses, so a camera whose frame
-    /// already arrives at close to native scale keeps the single cheap floor pass it does not need
-    /// replacing. Two rather than the 1.5 that turns cropping on: cropping is nearly free and tiling
-    /// is not.
+    /// already arrives at native scale keeps the single cheap floor pass it does not need replacing.
+    ///
+    /// <para><b>A worth-it guard, not a cost guard</b> — it asks whether tiling buys any scale at all.
+    /// Reading it as a cost guard gets the sign wrong: tile count grows with the squeeze, so a
+    /// *minimum*-gain threshold admits the expensive cameras and excludes the cheap ones. A 32:9
+    /// panoramic into 320² needs twelve tiles; a 16:9 stream into 512² needs two. What bounds the cost
+    /// is <see cref="TiledFloor"/> itself, and the inference budget behind it.</para>
     /// </summary>
-    public double TiledFloorMinGain { get; set; } = 2.0;
+    public double TiledFloorMinGain { get; set; } = 1.2;
+
+    /// <summary>
+    /// The largest sweep that is run whole, on every frame, instead of one tile at a time.
+    ///
+    /// <para>The two schedules make different promises. Run whole, a sweep examines every pixel every
+    /// frame and is a strict replacement for the shrunken whole-frame pass. Spread one tile per frame,
+    /// it examines a given pixel once per cycle — a real coverage cut that only motion and track crops
+    /// make up for.</para>
+    ///
+    /// <para>2 is what a 16:9 camera costs against a square input: a 640x360 frame into 512² is two
+    /// 512x360 tiles, so the guarantee doubles to two inferences per frame and buys the whole picture at
+    /// 1.00x rather than 0.80x. A panoramic into the same input needs twelve, which is not a guarantee a
+    /// host can make, so anything that wide keeps the spread sweep.</para>
+    ///
+    /// <para>Raising this multiplies the reserved, unsheddable cost of every camera it reaches; check it
+    /// against the <c>Detection budget</c> line.</para>
+    /// </summary>
+    public int SweepAtOnce { get; set; } = 2;
 
     /// <summary>
     /// Fraction of a tile that neighbouring tiles share.
@@ -663,12 +708,40 @@ public sealed record RegionOptions
 
     /// <summary>
     /// The least a region may be shrunk to reach the detector's input, as a fraction of the
-    /// frame's own pixels — the ceiling <see cref="MinSizeFraction"/> is the floor of. Below it a
-    /// small detector does not merely miss things, it invents them; the default is the guard
-    /// against the merge-chain runaway on <see cref="MotionRegions.AddMerged"/>, and the measured
-    /// per-model boundaries are in <c>Docs/detection.md</c>.
+    /// frame's own pixels. Below it a small detector does not merely miss things, it invents them;
+    /// the default is the guard against the merge-chain runaway on
+    /// <see cref="MotionRegions.AddMerged"/>, and the measured per-model boundaries are in
+    /// <c>Docs/detection.md</c>.
+    ///
+    /// <para>The other end of the same axis is <see cref="MaxRegionScale"/>. These two are a pair, in
+    /// the same units; <see cref="MinSizeFraction"/> is not — it is a fraction of the frame, and
+    /// bounds context rather than scale.</para>
     /// </summary>
     public double MinRegionScale { get; set; } = 0.5;
+
+    /// <summary>
+    /// The most a region may be <em>enlarged</em> to reach the detector's input — the ceiling on
+    /// magnification, where <see cref="MinRegionScale"/> is the floor.
+    ///
+    /// <para><b>One means a crop is never enlarged, only ever shrunk,</b> and that is the default
+    /// because enlarging does not add detail, it invents it. Measured against a car found in all sixty
+    /// of sixty whole frames at 0.906 mean confidence: at 1.25x it was still found in all sixty and
+    /// scored marginally better, at 2x in twenty-seven, and at 2.75x in none at all. The curve is
+    /// monotonic and every point past about 1.25x is worse than not cropping.</para>
+    ///
+    /// <para><b>This is the guard <see cref="MinSizeFraction"/> cannot be.</b> That one is stated in
+    /// frame units, so it cannot express "too tight for this detector": a crop is enlarged whenever the
+    /// input is bigger than <see cref="MinSizeFraction"/> of the frame, which at the defaults is every
+    /// camera under 4x <see cref="Gain"/> — nearly all of them.</para>
+    ///
+    /// <para><b>It costs no magnification that was ever real.</b> A crop's magnification over the
+    /// whole-frame pass is its scale divided by the whole frame's fit, so holding scale at 1.0 leaves
+    /// the maximum at exactly <see cref="Gain"/> — all of the detail the camera has over the input, and
+    /// none of the invented kind.</para>
+    ///
+    /// <para>Zero switches it off, the way zero switches off <see cref="MinRegionScale"/>.</para>
+    /// </summary>
+    public double MaxRegionScale { get; set; } = 1.0;
 
     /// <summary>
     /// Whether crops are cut, for a given frame and the input shape that frame resolves to.
@@ -742,6 +815,42 @@ public sealed record RegionOptions
         return (
             Math.Max(input.Width, (int)(input.Width / MinRegionScale)),
             Math.Max(input.Height, (int)(input.Height / MinRegionScale)));
+    }
+
+    /// <summary>
+    /// The smallest region that can still reach this input without being enlarged past
+    /// <see cref="MaxRegionScale"/>, in frame pixels — the mirror of <see cref="MaxRegion"/>.
+    ///
+    /// <para>Rounded <em>up</em>, where <see cref="MaxRegion"/> rounds down. Both err toward the guard:
+    /// a floor one pixel short would leave the scale marginally above the limit.</para>
+    ///
+    /// <para>Never larger than <see cref="MaxRegion"/>, so a configuration whose two bounds cross
+    /// resolves in favour of the ceiling. The ceiling guards against a detector inventing objects and
+    /// the floor only against it missing them, and without the clamp the contradiction would resolve
+    /// silently and by accident of ordering — grown by <see cref="MotionRegions.Fit"/>, refused by
+    /// <see cref="MotionRegions.AddMerged"/>, then cut back down by the split.</para>
+    ///
+    /// <para>Both axes, for the reason <see cref="MaxRegion"/> gives.</para>
+    /// </summary>
+    /// <returns>The bound, or null when it cannot apply — no input, or a scale of zero, which is how an
+    /// operator switches this off.</returns>
+    public (int Width, int Height)? MinRegion(DetectorInput input)
+    {
+        if (MaxRegionScale <= 0 || input.Width <= 0 || input.Height <= 0)
+        {
+            return null;
+        }
+
+        int width = (int)Math.Ceiling(input.Width / MaxRegionScale);
+        int height = (int)Math.Ceiling(input.Height / MaxRegionScale);
+
+        if (MaxRegion(input) is { } ceiling)
+        {
+            width = Math.Min(width, ceiling.Width);
+            height = Math.Min(height, ceiling.Height);
+        }
+
+        return (width, height);
     }
 }
 

--- a/Shared/Serval.Ai.Core/MotionRegions.cs
+++ b/Shared/Serval.Ai.Core/MotionRegions.cs
@@ -28,6 +28,9 @@ internal static class MotionRegions
     /// <param name="options">Cluster size floor, padding and cap.</param>
     /// <param name="max">The largest a region may be, or null for no bound. Clusters are merged within
     /// it and anything still over it is cut, so no rectangle returned here is ever larger.</param>
+    /// <param name="min">The smallest a region may be, or null for no bound — the size below which
+    /// reaching the detector's input would mean enlarging it. Applied by <see cref="Fit"/>, so a motion
+    /// crop and a track crop of the same subject are bounded identically.</param>
     public static IReadOnlyList<FrameRegion> Cluster(
         ReadOnlySpan<byte> changedCells,
         int gridWidth,
@@ -35,7 +38,8 @@ internal static class MotionRegions
         int frameWidth,
         int frameHeight,
         RegionOptions options,
-        (int Width, int Height)? max = null)
+        (int Width, int Height)? max = null,
+        (int Width, int Height)? min = null)
     {
         if (gridWidth <= 0 || gridHeight <= 0
             || changedCells.Length < gridWidth * gridHeight)
@@ -143,7 +147,7 @@ internal static class MotionRegions
 
             AddMerged(
                 regions,
-                Fit(left, top, right, bottom, frameWidth, frameHeight, options.MinSizeFraction),
+                Fit(left, top, right, bottom, frameWidth, frameHeight, options.MinSizeFraction, min),
                 max);
         }
 
@@ -181,12 +185,14 @@ internal static class MotionRegions
         double bottom,
         int frameWidth,
         int frameHeight,
-        double minSizeFraction) =>
+        double minSizeFraction,
+        (int Width, int Height)? min = null) =>
         Grow(
             Clamp(left, top, right, bottom, frameWidth, frameHeight),
             frameWidth,
             frameHeight,
-            minSizeFraction);
+            minSizeFraction,
+            min);
 
     /// <summary>
     /// Adds a crop, folding it into an existing one it overlaps as long as the result stays inside
@@ -346,12 +352,31 @@ internal static class MotionRegions
     /// footage, a crop tight enough to cut a truck in half returned nothing at all — not the person
     /// it was centred on, and not the truck either — while a larger crop of the same scene found the
     /// truck at 0.84. Magnification past that point costs more evidence than it buys.
+    ///
+    /// <para>Two floors, and the larger wins. <paramref name="minSizeFraction"/> is a share of the
+    /// frame and bounds how much context comes with the subject; <paramref name="min"/> comes from the
+    /// detector's input and bounds magnification, being the size below which reaching that input would
+    /// mean enlarging the crop. They answer different questions and neither implies the other.</para>
+    ///
+    /// <para>Both sit inside the clamp to the frame, which is why a frame shorter than
+    /// <paramref name="min"/> still yields a region inside it: a region grown past the frame would be
+    /// trimmed by <see cref="FramePreparer"/> afterwards, and the prepared geometry would then describe
+    /// a rectangle nobody asked for. Clamping the slack axis usually costs nothing, because a region's
+    /// scale is the *minimum* over its two axes — a 512x512 floor on a 360-tall frame gives 512x360,
+    /// which still reaches a 512x512 input at 1.00x.</para>
     /// </summary>
     private static FrameRegion Grow(
-        FrameRegion region, int frameWidth, int frameHeight, double minSizeFraction)
+        FrameRegion region,
+        int frameWidth,
+        int frameHeight,
+        double minSizeFraction,
+        (int Width, int Height)? min = null)
     {
-        int minWidth = Math.Min(frameWidth, (int)Math.Round(frameWidth * minSizeFraction));
-        int minHeight = Math.Min(frameHeight, (int)Math.Round(frameHeight * minSizeFraction));
+        int floorWidth = Math.Max((int)Math.Round(frameWidth * minSizeFraction), min?.Width ?? 0);
+        int floorHeight = Math.Max((int)Math.Round(frameHeight * minSizeFraction), min?.Height ?? 0);
+
+        int minWidth = Math.Min(frameWidth, floorWidth);
+        int minHeight = Math.Min(frameHeight, floorHeight);
 
         if (region.Width >= minWidth && region.Height >= minHeight)
         {

--- a/Shared/Serval.Ai.Core/ObjectEventPolicy.cs
+++ b/Shared/Serval.Ai.Core/ObjectEventPolicy.cs
@@ -140,6 +140,11 @@ public sealed class ObjectEventPolicy
         public int FrameCount;
         public List<TrackSample> Track = [];
         public bool IsAlert;
+
+        /// <summary>Whether this episode is the kind that may raise an alert, leaving only the
+        /// question of whether it is ever seen clearly enough. Settled when the episode opens.</summary>
+        public bool IsAlertEligible;
+
         public bool IsArrival;
     }
 
@@ -412,6 +417,24 @@ public sealed class ObjectEventPolicy
                     open.PeakFrameAt = now;
                     open.BestBox = box;
                 }
+
+                // The confidence half of the alert decision, re-asked until it passes and then never
+                // again. An alert says a thing of this class turned up and was at some point seen
+                // this clearly; which frame carried that certainty is a property of the detection
+                // schedule rather than of what happened.
+                //
+                // Judging only the opening frame would penalise examining a subject early: the first
+                // look at an arrival is the one where they are furthest away and smallest, so a
+                // visitor walking up a path is least convincing in the moment they appear.
+                //
+                // Inside `measured` for the reason the peak update is: a coasting track is where the
+                // filter predicts, and an alert must not fire on a frame nobody looked at.
+                if (!open.IsAlert
+                    && open.IsAlertEligible
+                    && track.Score >= _options.AlertMinConfidence)
+                {
+                    open.IsAlert = true;
+                }
             }
 
             AppendTrack(open.Track, now, box);
@@ -442,6 +465,12 @@ public sealed class ObjectEventPolicy
                     BestBox = box,
                     FrameCount = 1,
                     IsAlert = open.IsAlert,
+
+                    // Carried across, unlike IsArrival: eligibility is a fact about the object that
+                    // turned up and the clock running out does not unmake it. A presence not yet seen
+                    // clearly enough when it was cut must still be able to earn its alert afterwards,
+                    // which is also why this is stored rather than derived from IsArrival.
+                    IsAlertEligible = open.IsAlertEligible,
                     IsArrival = false,
                 };
 
@@ -758,17 +787,15 @@ public sealed class ObjectEventPolicy
     {
         bool isArrival = IsArrival(track);
 
-        // An alert is decided once, when the episode opens, and does not change afterwards. A
-        // record that quietly became an alert twenty seconds after someone read it would be worse
-        // than one that never claimed to be.
+        // Whether this episode may raise an alert at all — the half of the decision settled here,
+        // because neither part can become more true later. Whether it was ever seen clearly enough is
+        // asked on every measured frame until it passes.
         //
-        // Only an arrival can be one. Presence is not news — the scenery a camera opened on and a
+        // Only an arrival qualifies. Presence is not news — the scenery a camera opened on and a
         // thing that came back to where it just left are both already known about — and an alert
         // that fires on them is the whole feed. IsArrival is the question this file exists to
         // answer, and the alert flag is the one consumer that most needs the answer.
-        bool isAlert = isArrival
-            && _alerts.Contains(track.Label)
-            && track.Score >= _options.AlertMinConfidence;
+        bool isEligible = isArrival && _alerts.Contains(track.Label);
 
         // Where the previous episode of this same track ended, if it had one.
         DateTimeOffset? previous =
@@ -804,7 +831,12 @@ public sealed class ObjectEventPolicy
                 // ago — carrying its lifetime total across would restate every frame the first
                 // episode already reported.
                 FrameCount = previous is null ? Math.Max(track.Hits - 1, 0) : 0,
-                IsAlert = isAlert,
+
+                // Never set here, even well above the threshold: the frame that opens an episode is
+                // processed by the promoting pass immediately after this returns, so a confident
+                // arrival still alerts on its opening frame and the test lives in one place.
+                IsAlert = false,
+                IsAlertEligible = isEligible,
                 IsArrival = isArrival,
             },
         };

--- a/Shared/Serval.Ai.Core/OverlappingRegions.cs
+++ b/Shared/Serval.Ai.Core/OverlappingRegions.cs
@@ -1,0 +1,69 @@
+namespace Serval.Ai;
+
+/// <summary>
+/// Folds together detections that two overlapping regions made of the same object.
+///
+/// <para>Regions in one frame may overlap — a sweep run whole has tiles that share most of their width,
+/// and a motion crop routinely sits inside the tile that would have found the same thing. Each is a
+/// separate inference, so a subject in the shared area comes back once per region.</para>
+///
+/// <para><see cref="ObjectTracker"/> cannot absorb that: association is one detection to one track, so
+/// the second copy matches nothing and starts a track of its own. Both then arrive on every frame, both
+/// confirm, and one object becomes two episodes and two alerts. Suppressing here rather than inside the
+/// association rules keeps it a property of how the frame was examined, which is what it is.</para>
+///
+/// <para>Per label, for the reason the detector's own suppression is per class: a dog in front of its
+/// owner is two boxes over nearly the same pixels, and merging those loses the object that matters.</para>
+/// </summary>
+public static class OverlappingRegions
+{
+    /// <summary>
+    /// Overlap at or above which two boxes of one label are the same object seen twice.
+    ///
+    /// The same figure the detector's own suppression uses within a single inference
+    /// (<c>YoloDflPostprocessor.OverlapLimit</c>): a pair it would have merged inside one region must
+    /// not survive by having been found in two.
+    /// </summary>
+    public const float OverlapLimit = 0.4f;
+
+    /// <summary>
+    /// Everything found across a frame's regions, with duplicate sightings of one object reduced to the
+    /// highest-scoring copy.
+    ///
+    /// <para>Returned strongest first rather than in the order found, which is what makes the greedy
+    /// pass correct: a weaker duplicate is only ever dropped in favour of one already kept, so the box
+    /// that survives is the best look any region got at the object.</para>
+    /// </summary>
+    /// <param name="found">Detections from every region examined this frame, in frame coordinates.</param>
+    public static IReadOnlyList<DetectedObject> Fold(IReadOnlyList<DetectedObject> found)
+    {
+        if (found.Count < 2)
+        {
+            return found;
+        }
+
+        List<DetectedObject> kept = [];
+
+        foreach (DetectedObject candidate in found.OrderByDescending(static d => d.Score))
+        {
+            bool duplicate = false;
+
+            foreach (DetectedObject held in kept)
+            {
+                if (string.Equals(held.Label, candidate.Label, StringComparison.Ordinal)
+                    && ObjectTracker.Overlap(held.Box, candidate.Box) >= OverlapLimit)
+                {
+                    duplicate = true;
+                    break;
+                }
+            }
+
+            if (!duplicate)
+            {
+                kept.Add(candidate);
+            }
+        }
+
+        return kept;
+    }
+}

--- a/Shared/Serval.Ai.Core/RegionPlanner.cs
+++ b/Shared/Serval.Ai.Core/RegionPlanner.cs
@@ -96,8 +96,17 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
     /// <para>Crops are grown toward it, which costs nothing: the scale is set by whichever axis is
     /// squeezed hardest, so the slack one is free to fill. It affects the opportunistic half only, for
     /// the reason <paramref name="maxRegion"/> does.</para></param>
+    /// <param name="minRegion">The smallest crop that can still reach the detector without being
+    /// enlarged past <see cref="RegionOptions.MaxRegionScale"/>, or null for no bound. Resolved by the
+    /// caller from <see cref="RegionOptions.MinRegion"/>, in frame pixels, for the reason the arguments
+    /// above are.
+    ///
+    /// <para>It bounds the opportunistic half only, and clamps to the frame: a frame smaller than the
+    /// bound gives what it has. The floor and a sweep tile are already at or below the detector's own
+    /// shape, so neither has anything to bound.</para></param>
     /// <returns>Regions to examine, or empty when this frame needs no inference at all. None is ever
-    /// larger than <paramref name="maxRegion"/>.</returns>
+    /// larger than <paramref name="maxRegion"/>, and no crop is smaller than
+    /// <paramref name="minRegion"/> clamped to the frame.</returns>
     public IReadOnlyList<PlannedRegion> Plan(
         DateTimeOffset now,
         int frameWidth,
@@ -109,10 +118,31 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
         IReadOnlyList<TrackedObject> tracks,
         IReadOnlyList<FrameRegion>? floorTiles = null,
         (int Width, int Height)? maxRegion = null,
-        double inputAspect = 0)
+        double inputAspect = 0,
+        (int Width, int Height)? minRegion = null)
     {
         var whole = new FrameRegion(0, 0, frameWidth, frameHeight);
         bool floorDue = now - _lastFloorAt >= TimeSpan.FromSeconds(Math.Max(options.FloorSeconds, 0));
+
+        // Small enough to run whole: the sweep is then a like-for-like replacement for the whole-frame
+        // pass — every pixel every frame, at native scale instead of shrunk — so it stands on its own
+        // and does not need cropping on to be safe. Checked before the spread sweep below, because a
+        // camera that qualifies for this wants it whether or not it is also cutting crops.
+        if (floorTiles is { Count: > 1 } atOnce && atOnce.Count <= options.SweepAtOnce)
+        {
+            _lastFloorAt = now;
+
+            List<PlannedRegion> sweep = [.. atOnce.Select(static tile => new PlannedRegion(tile, RegionReason.Tile))];
+
+            if (cropping)
+            {
+                sweep.AddRange(
+                    PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion, minRegion));
+            }
+
+            return sweep;
+        }
+
         bool tiling = cropping && floorTiles is { Count: > 1 };
 
         if (!cropping)
@@ -149,7 +179,7 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
                 if (!floorDue)
                 {
                     // Sweep finished and the next one is not due. Fall through to motion and tracks.
-                    return PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion);
+                    return PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion, minRegion);
                 }
 
                 _sweepIndex = 0;
@@ -160,7 +190,7 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
 
             List<PlannedRegion> withTile = [new PlannedRegion(tile, RegionReason.Tile)];
             withTile.AddRange(
-                PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion));
+                PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion, minRegion));
 
             return withTile;
         }
@@ -174,7 +204,7 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
             return [new PlannedRegion(whole, RegionReason.Floor)];
         }
 
-        return PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion);
+        return PlanCrops(now, frameWidth, frameHeight, changedCells, gridWidth, gridHeight, tracks, inputAspect, maxRegion, minRegion);
     }
 
     /// <summary>
@@ -191,7 +221,8 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
         int gridHeight,
         IReadOnlyList<TrackedObject> tracks,
         double inputAspect,
-        (int Width, int Height)? maxRegion)
+        (int Width, int Height)? maxRegion,
+        (int Width, int Height)? minRegion)
     {
         int cap = Math.Max(options.MaxPerFrame, 1);
         List<PlannedRegion> planned = [];
@@ -200,7 +231,7 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
         // Tracks before motion: losing a track fragments an episode that already exists, where
         // missing a motion cluster costs at worst a later acquisition the floor still guarantees.
         // Merging means a group standing together is one crop rather than one each.
-        foreach (FrameRegion region in Tracked(tracks, frameWidth, frameHeight, maxRegion))
+        foreach (FrameRegion region in Tracked(tracks, frameWidth, frameHeight, maxRegion, minRegion))
         {
             if (planned.Count >= cap)
             {
@@ -217,7 +248,7 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
         }
 
         IReadOnlyList<FrameRegion> motion = MotionRegions.Cluster(
-            changedCells, gridWidth, gridHeight, frameWidth, frameHeight, options, maxRegion);
+            changedCells, gridWidth, gridHeight, frameWidth, frameHeight, options, maxRegion, minRegion);
 
         foreach (FrameRegion region in motion)
         {
@@ -295,7 +326,8 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
         IReadOnlyList<TrackedObject> tracks,
         int frameWidth,
         int frameHeight,
-        (int Width, int Height)? maxRegion)
+        (int Width, int Height)? maxRegion,
+        (int Width, int Height)? minRegion)
     {
         if (tracks.Count == 0)
         {
@@ -335,7 +367,8 @@ public sealed class RegionPlanner(RegionOptions options, IReadOnlyList<Detection
                     ((box.Y + box.Height) * frameHeight) + padY,
                     frameWidth,
                     frameHeight,
-                    options.MinSizeFraction),
+                    options.MinSizeFraction,
+                    minRegion),
                 maxRegion);
         }
 

--- a/Shared/Serval.Ai.Tests/AcquisitionTests.cs
+++ b/Shared/Serval.Ai.Tests/AcquisitionTests.cs
@@ -1,0 +1,246 @@
+using Serval.Ai;
+
+namespace Serval.Ai.Tests;
+
+/// <summary>
+/// Whether a subject that is plainly there ever becomes an episode.
+///
+/// <para>Everything else about regions is measured one component at a time: the planner is asked what it
+/// proposes, the tracker is asked what it confirms. Both can be right while the system detects nothing,
+/// because the property that matters spans them — <b>a subject must be examined on enough consecutive
+/// frames for a track to confirm.</b> <see cref="ObjectTracker"/> drops a tentative track the moment one
+/// frame passes without matching it and will not confirm before
+/// <see cref="TrackingOptions.ConfirmSeconds"/>, so a schedule that looks somewhere else in between
+/// produces no episodes at all, however good each individual look was.</para>
+///
+/// <para>The failure is silent and total: a floor that reaches a subject only every few frames leaves
+/// every component passing its own tests while the camera records nothing at all.</para>
+///
+/// <para>These drive the real planner and the real tracker together over the geometries the shipped
+/// deployments run, with a subject that never moves — the hardest case, because it generates no motion
+/// for a crop to follow and depends entirely on the guaranteed floor.</para>
+/// </summary>
+public class AcquisitionTests
+{
+    private const double Fps = 2.0;
+
+    /// <summary>
+    /// Every camera geometry in <c>docker-compose.intel-coral.yml</c>, with how long its floor is allowed
+    /// to take to believe a subject that arrives and then stands still.
+    ///
+    /// <para>Two budgets, because there are two kinds of floor and they promise different things. A
+    /// <b>continuous</b> floor — the whole frame every frame, or a sweep short enough to run whole —
+    /// examines the subject from the moment it arrives, so it owes an answer within
+    /// <see cref="TrackingOptions.ConfirmSeconds"/> and a frame or two of slack. An <b>interval</b>
+    /// floor sweeps a tile at a time and returns to any given tile once per
+    /// <see cref="RegionOptions.FloorSeconds"/>, so in the worst case the subject waits most of that
+    /// interval out; between sweeps it is motion crops or nothing. That is the trade a camera makes by
+    /// being squeezed hard enough to need many tiles, and the panoramic has run it since it was
+    /// installed.</para>
+    ///
+    /// <para>The distinction is the whole point: a configuration change can move a camera from the
+    /// first kind to the second without anything else looking different.</para>
+    /// </summary>
+    public static TheoryData<string, int, int, int, int, double> Geometries() => new()
+    {
+        { "16:9 sub stream into a square accelerator", 640, 360, 512, 512, 2.0 },
+        { "doorbell, portrait, into a square accelerator", 480, 640, 512, 512, 2.0 },
+        { "a camera the detector already matches", 640, 360, 640, 384, 2.0 },
+        { "panoramic into a square accelerator", 1536, 432, 512, 512, 6.0 },
+    };
+
+    [Theory]
+    [MemberData(nameof(Geometries))]
+    public void A_still_subject_anywhere_in_the_frame_becomes_an_episode(
+        string geometry, int frameWidth, int frameHeight, int inputWidth, int inputHeight,
+        double budgetSeconds)
+    {
+        // Across the frame including both edges, because the edges are exactly what a sweep covers
+        // least often — a tile hangs flush to each end, so the outermost strips are in one tile only.
+        foreach (double at in new[] { 0.02, 0.25, 0.5, 0.75, 0.95 })
+        {
+            // Arriving partway through, at a moment falling *after* a sweep has completed rather than
+            // at the start of one. A subject present from the first frame is caught by the opening
+            // sweep whatever the schedule is, which hides the fault this exists to catch.
+            (bool confirmed, double after) =
+                Follow(frameWidth, frameHeight, inputWidth, inputHeight, at, appearsAt: 1.5);
+
+            Assert.True(
+                confirmed,
+                $"{geometry}: a subject at {at:P0} across the frame was never confirmed in 30 s, so it "
+                + "never became an episode — the schedule never examined it on enough consecutive "
+                + $"frames. Frame {frameWidth}x{frameHeight} into {inputWidth}x{inputHeight}.");
+
+            Assert.True(
+                after <= budgetSeconds,
+                $"{geometry}: a subject at {at:P0} across the frame took {after:0.0} s to be believed "
+                + $"after arriving, against a budget of {budgetSeconds:0.0} s. A camera on the "
+                + "continuous budget that slips to the interval one has had its floor thinned — "
+                + "whatever else changed, it now misses anything that passes through in a few seconds.");
+        }
+    }
+
+    /// <summary>
+    /// Runs the planner and the tracker against each other for 30 seconds and reports how long after the
+    /// subject arrived it was first believed. The subject is only ever detected in a region that wholly
+    /// contains it, which is the honest simplification: a detector given a crop that cuts an object in
+    /// half rarely returns the whole object, and never returns the box this asserts on.
+    /// </summary>
+    /// <param name="appearsAt">Seconds into the run before the subject exists at all. Nothing is
+    /// detectable before it, and the clock this returns starts here.</param>
+    private static (bool Confirmed, double After) Follow(
+        int frameWidth, int frameHeight, int inputWidth, int inputHeight, double across,
+        double appearsAt = 0)
+    {
+        var input = new DetectorInput(inputWidth, inputHeight, DetectorLayout.Uint8Nhwc, 1f);
+        var regions = new RegionOptions { TiledFloor = true };
+        var tracking = new TrackingOptions();
+
+        var planner = new RegionPlanner(regions);
+        var tracker = new ObjectTracker(tracking);
+
+        bool cropping = regions.ShouldCrop(frameWidth, frameHeight, input);
+        IReadOnlyList<FrameRegion>? tiles = regions.ShouldTileFloor(frameWidth, frameHeight, input)
+            ? DetectorShapes.Tiles(
+                frameWidth, frameHeight, input.Width, input.Height, regions.TileOverlapFraction)
+            : null;
+
+        // A subject about a tenth of the frame across, standing still on the ground line.
+        int width = Math.Max(16, frameWidth / 10);
+        int height = Math.Max(16, frameHeight / 5);
+        int x = Math.Clamp((int)(frameWidth * across) - (width / 2), 0, frameWidth - width);
+        int y = (frameHeight - height) / 2;
+
+        var start = new DateTimeOffset(2026, 8, 18, 12, 0, 0, TimeSpan.Zero);
+        int frames = (int)(30 * Fps);
+
+        for (int f = 0; f < frames; f++)
+        {
+            DateTimeOffset now = start.AddSeconds(f / Fps);
+
+            IReadOnlyList<PlannedRegion> planned = planner.Plan(
+                now,
+                frameWidth,
+                frameHeight,
+                cropping,
+                // Nothing moves, so nothing suggests where to look. Acquisition is the floor's job.
+                ReadOnlySpan<byte>.Empty,
+                0,
+                0,
+                [.. tracker.Live],
+                tiles,
+                regions.MaxRegion(input),
+                (double)input.Width / input.Height,
+                regions.MinRegion(input));
+
+            List<DetectedObject> found = [];
+
+            foreach (PlannedRegion region in planned)
+            {
+                if (f / Fps < appearsAt)
+                {
+                    break;
+                }
+
+                if (region.Region.X <= x
+                    && region.Region.Y <= y
+                    && region.Region.X + region.Region.Width >= x + width
+                    && region.Region.Y + region.Region.Height >= y + height)
+                {
+                    found.Add(new DetectedObject(
+                        "person",
+                        0.9f,
+                        new BoundingBox(
+                            (float)x / frameWidth,
+                            (float)y / frameHeight,
+                            (float)width / frameWidth,
+                            (float)height / frameHeight)));
+                }
+            }
+
+            // Exactly what the pipeline does with a frame's regions before the tracker sees them.
+            tracker.Update(OverlappingRegions.Fold(found), now);
+
+            if (tracker.Live.Any(static t => t.State == TrackState.Confirmed))
+            {
+                return (true, (f / Fps) - appearsAt);
+            }
+        }
+
+        return (false, 30);
+    }
+
+    [Fact]
+    public void A_sweep_short_enough_to_run_whole_covers_the_frame_on_every_frame()
+    {
+        // The property the fix rests on, stated directly: with a sweep of at most SweepAtOnce tiles,
+        // no frame examines less than the whole picture, so the cadence is the one a single shrunken
+        // pass gave and the scale is better. Asserted without the tracker so a failure says which of
+        // the two halves broke.
+        var regions = new RegionOptions { TiledFloor = true };
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+        var planner = new RegionPlanner(regions);
+
+        IReadOnlyList<FrameRegion> tiles =
+            DetectorShapes.Tiles(640, 360, 512, 512, regions.TileOverlapFraction);
+
+        Assert.Equal(2, tiles.Count);
+
+        var start = new DateTimeOffset(2026, 8, 18, 12, 0, 0, TimeSpan.Zero);
+
+        for (int f = 0; f < 40; f++)
+        {
+            IReadOnlyList<PlannedRegion> planned = planner.Plan(
+                start.AddSeconds(f / Fps), 640, 360,
+                regions.ShouldCrop(640, 360, input),
+                ReadOnlySpan<byte>.Empty, 0, 0, [], tiles,
+                regions.MaxRegion(input), 1.0, regions.MinRegion(input));
+
+            Assert.Equal(2, planned.Count(static p => p.Reason == RegionReason.Tile));
+
+            for (int column = 0; column < 640; column++)
+            {
+                Assert.Contains(
+                    planned,
+                    p => p.Region.X <= column && p.Region.X + p.Region.Width > column);
+            }
+        }
+    }
+
+    [Fact]
+    public void A_sweep_too_long_to_span_a_confirmation_cannot_acquire_a_still_subject()
+    {
+        // A known gap, pinned so it is visible rather than discovered. 1080p into a 640x384 input tiles
+        // four ways in each axis, so a spread sweep returns to any given tile once every sixteen frames
+        // — eight seconds apart, and never twice running. A subject that never moves generates no motion
+        // for a crop to follow, so nothing else looks either, and it is never confirmed.
+        //
+        // Shipped deployments do not meet this: TiledFloor is off unless asked for, and the geometries
+        // that ask for it are in the theory above. What closes it for a camera that hits it is
+        // RegionOptions.SweepAtOnce, at the cost of one reserved inference per tile per frame.
+        //
+        // If this test starts failing, the gap has been closed — delete it and move the geometry up.
+        (bool confirmed, _) = Follow(1920, 1080, 640, 384, 0.02, appearsAt: 1.5);
+
+        Assert.False(
+            confirmed,
+            "a long spread sweep now acquires a still subject at the frame edge, which it could not "
+            + "before — the sweep schedule has changed and this limitation no longer holds");
+    }
+
+    [Fact]
+    public void Turning_crops_on_must_never_thin_the_guarantee_below_a_confirmation()
+    {
+        // The rule that was broken, as a rule rather than as one camera's numbers: whatever the floor
+        // becomes when cropping is switched on, it must still be able to confirm a still subject on its
+        // own, because crops follow movement and a still subject makes none.
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+        var regions = new RegionOptions { TiledFloor = true, Mode = RegionMode.On };
+
+        Assert.True(regions.ShouldCrop(640, 360, input), "Mode.On must crop, or this proves nothing");
+
+        (bool confirmed, _) = Follow(640, 360, 512, 512, 0.5, appearsAt: 1.5);
+
+        Assert.True(confirmed, "a still subject in the middle of the frame was never confirmed");
+    }
+}

--- a/Shared/Serval.Ai.Tests/ObjectEventPolicyTests.cs
+++ b/Shared/Serval.Ai.Tests/ObjectEventPolicyTests.cs
@@ -800,25 +800,247 @@ public class ObjectEventPolicyTests
         Assert.True(arrival.IsAlert);
     }
 
-    [Fact]
-    public void An_alert_is_decided_at_open_and_does_not_change_later()
+    /// <summary>
+    /// Well past <see cref="DetectionOptions.NoveltySeconds"/>, so a track first seen here counts as
+    /// something that turned up rather than as scenery the camera opened on.
+    /// </summary>
+    private static readonly DateTimeOffset Later = T0.AddSeconds(300);
+
+    /// <summary>
+    /// A policy whose watch clock has already started, so the next thing it sees is an arrival.
+    /// Several of the alert tests need that and nothing else from the setup.
+    /// </summary>
+    private static ObjectEventPolicy Watching(Action<DetectionOptions>? configure = null)
     {
-        // A record that quietly became an alert after someone read it would be worse than one that
-        // never claimed to be.
-        var policy = Policy(o =>
+        ObjectEventPolicy policy = Policy(configure);
+        policy.Observe([], T0);
+        return policy;
+    }
+
+    [Fact]
+    public void An_arrival_that_only_later_reaches_the_threshold_still_alerts()
+    {
+        // Scores a doorbell camera actually reported for a visitor walking up a path. They are
+        // furthest away and smallest on the frame that opens their episode, so judging only that
+        // frame turns examining them early into a penalty.
+        var policy = Watching(o =>
         {
             o.AlertClasses = ["person"];
-            o.AlertMinConfidence = 0.9f;
+            o.AlertMinConfidence = 0.6f;
+        });
+
+        ObjectEpisode opened = Assert.Single(
+            policy.Observe([At(1, "person", 0.557f, 0.44f, 0.49f, since: Later)], Later).Live);
+
+        Assert.True(opened.IsArrival);
+        Assert.False(opened.IsAlert);
+
+        ObjectEpisode second = Assert.Single(
+            policy.Observe(
+                [At(1, "person", 0.605f, 0.44f, 0.49f, since: Later)], Later.AddSeconds(1)).Live);
+
+        Assert.True(second.IsAlert);
+    }
+
+    [Fact]
+    public void The_alert_flag_is_set_once_and_never_cleared()
+    {
+        // One-way on purpose: a record that stopped being an alert after someone read it would be
+        // worse than one that never claimed to be.
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+            o.ScoreThreshold = 0.25f;
             o.AbsenceSeconds = 5.0;
         });
 
-        policy.Observe([Seen(1, "person", 0.5f)], T0);
-        policy.Observe([Seen(1, "person", 0.99f)], T0.AddSeconds(2));
+        policy.Observe([At(1, "person", 0.4f, 0.7f, 0.6f, since: Later)], Later);
+        policy.Observe([At(1, "person", 0.95f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(1));
+        policy.Observe([At(1, "person", 0.3f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(2));
 
-        ObjectEpisode closed = policy.Observe([], T0.AddSeconds(30)).Published[0];
+        ObjectEpisode closed = Assert.Single(policy.Observe([], Later.AddSeconds(40)).Published);
+
+        Assert.True(closed.IsAlert);
+        Assert.Equal(0.95f, closed.PeakConfidence);
+    }
+
+    [Fact]
+    public void An_episode_that_never_reaches_the_threshold_never_alerts()
+    {
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.9f;
+            o.ScoreThreshold = 0.25f;
+            o.AbsenceSeconds = 5.0;
+        });
+
+        foreach (float score in new[] { 0.4f, 0.6f, 0.85f, 0.5f })
+        {
+            policy.Observe([At(1, "person", score, 0.7f, 0.6f, since: Later)], Later.AddSeconds(1));
+        }
+
+        ObjectEpisode closed = Assert.Single(policy.Observe([], Later.AddSeconds(40)).Published);
 
         Assert.False(closed.IsAlert);
-        Assert.Equal(0.99f, closed.PeakConfidence);
+    }
+
+    [Fact]
+    public void A_presence_that_is_not_an_arrival_never_alerts_however_confident()
+    {
+        // Eligibility is settled when the episode opens and no amount of later certainty revisits
+        // it. Without that guard a one-way confidence test would turn every piece of scenery into an
+        // alert the moment it happened to score well.
+        var policy = Policy(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+        });
+
+        // In shot from the moment watching began, so nothing turned up.
+        policy.Observe([At(1, "person", 0.5f, 0.1f, 0.2f)], T0);
+
+        for (int i = 1; i <= 10; i++)
+        {
+            ObjectEpisode live = Assert.Single(
+                policy.Observe([At(1, "person", 0.99f, 0.1f, 0.2f)], T0.AddSeconds(i)).Live);
+
+            Assert.False(live.IsArrival);
+            Assert.False(live.IsAlert);
+        }
+    }
+
+    [Fact]
+    public void A_class_outside_the_alert_list_never_alerts()
+    {
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+        });
+
+        ObjectEpisode live = Assert.Single(
+            policy.Observe([At(1, "car", 0.99f, 0.7f, 0.6f, since: Later)], Later).Live);
+
+        Assert.True(live.IsArrival);
+        Assert.False(live.IsAlert);
+    }
+
+    [Fact]
+    public void A_coasted_frame_cannot_raise_an_alert()
+    {
+        // Where the filter predicts, not where anything was seen. An alert must not fire on a frame
+        // nobody looked at, which is the same reason a coasted frame cannot set the peak.
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+            o.ScoreThreshold = 0.25f;
+        });
+
+        policy.Observe([At(1, "person", 0.4f, 0.7f, 0.6f, since: Later)], Later);
+
+        ObjectEpisode coasted = Assert.Single(
+            policy.Observe(
+                [At(1, "person", 0.99f, 0.7f, 0.6f, TrackState.Coasting, Later)],
+                Later.AddSeconds(1)).Live);
+
+        Assert.False(coasted.IsAlert);
+
+        ObjectEpisode measured = Assert.Single(
+            policy.Observe(
+                [At(1, "person", 0.7f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(2)).Live);
+
+        Assert.True(measured.IsAlert);
+    }
+
+    [Fact]
+    public void An_alert_carries_a_frame_at_or_above_the_threshold_it_fired_on()
+    {
+        // What the card shows and what the gate fired on are the same evidence. Without this an
+        // alert could display a confidence unrelated to the one it was judged at, and the number a
+        // reader sees would say nothing about why it fired.
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+            o.ScoreThreshold = 0.25f;
+        });
+
+        policy.Observe([At(1, "person", 0.42f, 0.7f, 0.6f, since: Later)], Later);
+
+        ObjectEpisode alerting = Assert.Single(
+            policy.Observe(
+                [At(1, "person", 0.71f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(1)).Live);
+
+        Assert.True(alerting.IsAlert);
+        Assert.NotNull(alerting.BestBox);
+        Assert.True(
+            alerting.BestBox!.Value.Score >= 0.6f,
+            $"alerted carrying a {alerting.BestBox.Value.Score:0.000} box, below the 0.600 it fired on");
+    }
+
+    [Fact]
+    public void A_continuation_of_an_alerting_presence_is_its_own_record()
+    {
+        // Deliberate: the hard cut ends one episode and starts another, and a new episode may raise
+        // its own alert. AlertService is idempotent on the episode id, so this is exactly what
+        // decides whether a long presence alerts once or hourly — asserted here because the ids are
+        // the mechanism and nothing else pins them.
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+            o.ScoreThreshold = 0.25f;
+            o.MaxEpisodeSeconds = 60.0;
+        });
+
+        policy.Observe([At(1, "person", 0.9f, 0.7f, 0.6f, since: Later)], Later);
+
+        ObjectObservation cut = policy.Observe(
+            [At(1, "person", 0.9f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(61));
+
+        ObjectEpisode first = Assert.Single(cut.Published);
+        ObjectEpisode second = Assert.Single(cut.Live);
+
+        Assert.True(first.IsAlert);
+        Assert.True(second.IsAlert);
+        Assert.NotEqual(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void A_continuation_can_still_reach_a_threshold_its_first_episode_never_did()
+    {
+        // The hard cut at MaxEpisodeSeconds opens a fresh episode that is explicitly not an arrival.
+        // Eligibility is carried across it anyway, because it is a fact about the object that turned
+        // up and the clock running out does not unmake it — otherwise "at any point during its
+        // episode" would quietly stop holding at the cut.
+        var policy = Watching(o =>
+        {
+            o.AlertClasses = ["person"];
+            o.AlertMinConfidence = 0.6f;
+            o.ScoreThreshold = 0.25f;
+            o.MaxEpisodeSeconds = 60.0;
+        });
+
+        policy.Observe([At(1, "person", 0.4f, 0.7f, 0.6f, since: Later)], Later);
+
+        // Past the cut: the first episode closes below the threshold and a continuation opens.
+        ObjectObservation cut = policy.Observe(
+            [At(1, "person", 0.45f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(61));
+
+        Assert.False(Assert.Single(cut.Published).IsAlert);
+
+        ObjectEpisode continuation = Assert.Single(cut.Live);
+        Assert.False(continuation.IsArrival);
+        Assert.False(continuation.IsAlert);
+
+        ObjectEpisode promoted = Assert.Single(
+            policy.Observe(
+                [At(1, "person", 0.8f, 0.7f, 0.6f, since: Later)], Later.AddSeconds(62)).Live);
+
+        Assert.True(promoted.IsAlert);
     }
 
     [Fact]

--- a/Shared/Serval.Ai.Tests/ObjectTrackerTests.cs
+++ b/Shared/Serval.Ai.Tests/ObjectTrackerTests.cs
@@ -20,6 +20,43 @@ public class ObjectTrackerTests
         new("person", score, new BoundingBox(x, y, 0.05f, 0.12f));
 
     [Fact]
+    public void A_subject_seen_on_alternate_frames_never_confirms()
+    {
+        // What a region plan that examines a subject every other frame costs, and the reason a tile
+        // sweep is not allowed to be the only thing looking: a tentative track is dropped the moment
+        // one frame passes without matching it, so its sightings never become consecutive and it never
+        // reaches confirmation. The filter would predict across the gap happily — the track does not
+        // survive to use it.
+        var tracker = new ObjectTracker(new TrackingOptions());
+
+        for (int frame = 0; frame < 12; frame++)
+        {
+            IReadOnlyList<TrackedObject> reported = frame % 2 == 0
+                ? tracker.Update([Person(0.5f, 0.5f)], At(frame))
+                : tracker.Update([], At(frame));
+
+            Assert.Empty(reported);
+        }
+
+        // Every one of the six sightings became its own one-frame ghost.
+        Assert.Equal(6, tracker.Ghosts);
+    }
+
+    [Fact]
+    public void A_subject_seen_on_consecutive_frames_confirms()
+    {
+        // The other half of the pair above, so the first reads as a statement about the sampling rate
+        // rather than about the tracker being unable to confirm anything at all.
+        var tracker = new ObjectTracker(new TrackingOptions());
+
+        Assert.Empty(tracker.Update([Person(0.5f, 0.5f)], At(0)));
+        Assert.Empty(tracker.Update([Person(0.5f, 0.5f)], At(1)));
+
+        Assert.NotEmpty(tracker.Update([Person(0.5f, 0.5f)], At(2)));
+        Assert.Equal(0, tracker.Ghosts);
+    }
+
+    [Fact]
     public void A_single_sighting_is_never_reported()
     {
         // The whole reason tentative tracks exist. A confident one-frame ghost is indistinguishable

--- a/Shared/Serval.Ai.Tests/RegionPlannerTests.cs
+++ b/Shared/Serval.Ai.Tests/RegionPlannerTests.cs
@@ -235,8 +235,16 @@ public class RegionPlannerTests
     // A 3:4 doorbell into a landscape input: 0.75x across but 1.67x down, and the squeezed axis is
     // the one that decides. Reading width alone declines to crop the camera that needs it most.
     [InlineData(480, 640, 640, 384, RegionMode.Auto, true)]     // 1.67x on the vertical
-    // The same doorbell into a shape at its own aspect needs no crop to see properly.
+    // The same doorbell into a shape at its own aspect needs no crop to see properly, and at 1.15x it
+    // is the nearest case to the threshold on the declining side.
     [InlineData(480, 640, 416, 576, RegionMode.Auto, false)]    // 1.15x
+    // A 16:9 sub stream into a fixed square accelerator input, the shape a compiled 512² graph gives
+    // every camera. Declined, and this pair is the case the threshold exists for: with MaxRegionScale
+    // holding a crop to native scale the smallest crop here is 512x360 out of 640x360, four fifths of
+    // the frame, and cropping would cost the every-frame floor to buy it. TiledFloor is what gives
+    // these cameras native scale.
+    [InlineData(640, 360, 512, 512, RegionMode.Auto, false)]    // 1.25x
+    [InlineData(480, 640, 512, 512, RegionMode.Auto, false)]    // 1.25x, the doorbell's portrait of it
     public void Auto_decides_from_the_frame_to_input_ratio(
         int frameWidth, int frameHeight, int inputWidth, int inputHeight,
         RegionMode mode, bool expected)
@@ -778,6 +786,59 @@ public class RegionPlannerTests
     }
 
     [Fact]
+    public void A_piece_of_a_cut_region_is_never_below_the_floor()
+    {
+        // The preservation property that makes the floor an invariant rather than a suggestion. A
+        // region too large for the ceiling is cut into pieces sized by the ceiling, and because the two
+        // bounds cannot cross, a piece is never smaller than the floor. Without that, the last stage of
+        // the chain would quietly undo the first.
+        var options = Roomy();
+        options.MaxRegionScale = 1.0;
+        var input = new DetectorInput(320, 320, DetectorLayout.Uint8Nhwc, 1f);
+        (int Width, int Height)? min = options.MinRegion(input);
+
+        var planner = new RegionPlanner(options);
+        planner.Plan(Start, WideWidth, WideHeight, true, Still(), Grid, GridHeight, [], null, Bound, 0, min);
+
+        IReadOnlyList<PlannedRegion> planned = planner.Plan(
+            Start.AddSeconds(1), WideWidth, WideHeight, true, Moving(0, 0, Grid, GridHeight),
+            Grid, GridHeight, [], null, Bound, 0, min);
+
+        Assert.True(planned.Count > 1);
+        Assert.All(planned, region =>
+        {
+            Assert.True(
+                region.Region.Width >= Math.Min(WideWidth, min!.Value.Width),
+                $"a piece {region.Region.Width}px wide is under the {min!.Value.Width}px floor");
+            Assert.True(region.Region.Height >= Math.Min(WideHeight, min!.Value.Height));
+        });
+    }
+
+    [Fact]
+    public void Shaping_to_aspect_cannot_shrink_a_bounded_crop()
+    {
+        // Shaping only ever grows, so a crop already at the floor stays there whatever aspect it is
+        // asked to take. Checked with a square input against a 32:9 frame, which is the case where
+        // shaping moves a crop the most.
+        var options = Roomy();
+        options.MaxRegionScale = 1.0;
+        var input = new DetectorInput(320, 320, DetectorLayout.Uint8Nhwc, 1f);
+        (int Width, int Height)? min = options.MinRegion(input);
+
+        var planner = new RegionPlanner(options);
+        planner.Plan(Start, WideWidth, WideHeight, true, Still(), Grid, GridHeight, [], null, Bound, Square, min);
+
+        IReadOnlyList<PlannedRegion> planned = planner.Plan(
+            Start.AddSeconds(1), WideWidth, WideHeight, true, Moving(30, 20, 2, 2),
+            Grid, GridHeight, [], null, Bound, Square, min);
+
+        PlannedRegion only = Assert.Single(planned);
+
+        Assert.True(only.Region.Width >= min!.Value.Width);
+        Assert.True(only.Region.Height >= Math.Min(WideHeight, min!.Value.Height));
+    }
+
+    [Fact]
     public void Pieces_of_a_cut_region_stay_sheddable()
     {
         // Not cosmetic. InferenceScheduler reserves the floor and sweep tiles outside the budget and
@@ -874,6 +935,166 @@ public class RegionPlannerTests
         var options = new RegionOptions { MinRegionScale = 0 };
 
         Assert.Null(options.MaxRegion(new DetectorInput(320, 320, DetectorLayout.Uint8Nhwc, 1f)));
+    }
+
+    // ---- The magnification limit ----
+    //
+    // The mirror of the ceiling above, and the one that binds on ordinary cameras. A crop smaller than
+    // the input is enlarged to reach it, and enlarging does not add detail. Measured against a car found
+    // in all sixty of sixty whole frames at 0.906: at 1.25x still sixty, at 2x twenty-seven, at 2.75x
+    // none. So the floor is stated against the input rather than against the frame.
+
+    [Theory]
+    [InlineData(512, 512, 1.0, 512, 512)]
+    [InlineData(640, 384, 1.0, 640, 384)]
+    [InlineData(512, 512, 1.25, 410, 410)]
+    public void The_floor_is_the_input_divided_by_the_magnification_limit(
+        int inputWidth, int inputHeight, double limit, int expectedWidth, int expectedHeight)
+    {
+        var options = new RegionOptions { MaxRegionScale = limit };
+
+        (int Width, int Height)? min = options.MinRegion(
+            new DetectorInput(inputWidth, inputHeight, DetectorLayout.Uint8Nhwc, 1f));
+
+        Assert.Equal((expectedWidth, expectedHeight), min);
+    }
+
+    [Fact]
+    public void A_magnification_limit_of_zero_switches_the_floor_off()
+    {
+        var options = new RegionOptions { MaxRegionScale = 0 };
+
+        Assert.Null(options.MinRegion(new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f)));
+    }
+
+    [Fact]
+    public void The_floor_can_never_exceed_the_ceiling()
+    {
+        // A configuration whose two bounds cross resolves in favour of the ceiling: it guards against a
+        // detector inventing objects, where the floor only guards against it missing them. Left to
+        // resolve itself the contradiction would come out differently depending on ordering — grown by
+        // Fit, refused by AddMerged, then cut back down by the split.
+        var options = new RegionOptions { MaxRegionScale = 0.5, MinRegionScale = 1.0 };
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+
+        (int Width, int Height)? min = options.MinRegion(input);
+        (int Width, int Height)? max = options.MaxRegion(input);
+
+        Assert.Equal(max, min);
+    }
+
+    [Fact]
+    public void A_crop_is_never_magnified_past_the_limit()
+    {
+        // Stated as the goal rather than as the mechanism, and measured the way FramePreparer measures
+        // it, so the assertion cannot drift from what the detector is actually shown.
+        var options = Options();
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+        var planner = new RegionPlanner(options);
+
+        planner.Plan(
+            Start, FrameWidth, FrameHeight, true, Still(), Grid, GridHeight,
+            [], null, options.MaxRegion(input), 1.0, options.MinRegion(input));
+
+        IReadOnlyList<PlannedRegion> planned = planner.Plan(
+            Start.AddSeconds(1), FrameWidth, FrameHeight, true, Moving(30, 20, 2, 2), Grid, GridHeight,
+            [], null, options.MaxRegion(input), 1.0, options.MinRegion(input));
+
+        PlannedRegion only = Assert.Single(planned);
+
+        double scale = Math.Min(
+            (double)input.Width / only.Region.Width, (double)input.Height / only.Region.Height);
+
+        Assert.True(
+            scale <= options.MaxRegionScale,
+            $"a {only.Region.Width}x{only.Region.Height} crop reaches a {input.Width}x{input.Height} "
+            + $"input at {scale:0.00}x, past the {options.MaxRegionScale:0.00}x limit");
+    }
+
+    [Fact]
+    public void The_floor_clamps_to_the_frame_and_still_holds()
+    {
+        // The counter-intuitive case. A 512x512 floor on a 360-tall frame cannot be honoured on the
+        // vertical, and does not need to be: a region's scale is the minimum over its two axes, so
+        // clamping the slack one costs nothing and 512x360 still reaches a 512x512 input at 1.00x.
+        var options = new RegionOptions { Mode = RegionMode.On, FloorSeconds = 5, MinCells = 4, PaddingFraction = 0 };
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+        var planner = new RegionPlanner(options);
+
+        planner.Plan(
+            Start, 640, 360, true, Still(), Grid, GridHeight,
+            [], null, options.MaxRegion(input), 1.0, options.MinRegion(input));
+
+        PlannedRegion only = Assert.Single(planner.Plan(
+            Start.AddSeconds(1), 640, 360, true, Moving(30, 20, 2, 2), Grid, GridHeight,
+            [], null, options.MaxRegion(input), 1.0, options.MinRegion(input)));
+
+        Assert.Equal(360, only.Region.Height);
+        Assert.True(only.Region.Width >= 512, $"crop was only {only.Region.Width}px wide");
+        Assert.InRange(only.Region.X + only.Region.Width, 0, 640);
+
+        double scale = Math.Min(
+            (double)input.Width / only.Region.Width, (double)input.Height / only.Region.Height);
+
+        Assert.Equal(1.0, scale, 3);
+    }
+
+    [Fact]
+    public void A_camera_with_enough_gain_is_untouched_by_the_limit()
+    {
+        // The compatibility guarantee. Where MinSizeFraction already floors a crop above the input, the
+        // limit has nothing to add and the plan is identical with and without it.
+        var options = Options();
+        var input = new DetectorInput(640, 384, DetectorLayout.FloatNchw);
+        (int Width, int Height)? max = options.MaxRegion(input);
+
+        var bounded = new RegionPlanner(options);
+        var unbounded = new RegionPlanner(options);
+
+        bounded.Plan(Start, 3840, 2160, true, Still(), Grid, GridHeight, [], null, max, 0, options.MinRegion(input));
+        unbounded.Plan(Start, 3840, 2160, true, Still(), Grid, GridHeight, [], null, max, 0);
+
+        IReadOnlyList<PlannedRegion> withLimit = bounded.Plan(
+            Start.AddSeconds(1), 3840, 2160, true, Moving(30, 20, 2, 2), Grid, GridHeight,
+            [], null, max, 0, options.MinRegion(input));
+
+        IReadOnlyList<PlannedRegion> without = unbounded.Plan(
+            Start.AddSeconds(1), 3840, 2160, true, Moving(30, 20, 2, 2), Grid, GridHeight,
+            [], null, max, 0);
+
+        Assert.Equal(without, withLimit);
+    }
+
+    [Fact]
+    public void A_track_crop_and_a_motion_crop_of_the_same_subject_agree_under_the_limit()
+    {
+        // The invariant MotionRegions.Fit exists for: a subject must be handed to the detector the same
+        // way whichever proposer named it, or it scores differently for no reason in the scene.
+        var options = Options();
+        var input = new DetectorInput(512, 512, DetectorLayout.Uint8Nhwc, 1f);
+        (int Width, int Height)? max = options.MaxRegion(input);
+        (int Width, int Height)? min = options.MinRegion(input);
+
+        // Cells 30-31 of 64 across, 20-21 of 48 down, as a normalised box.
+        var box = new BoundingBox(
+            30f / Grid, 20f / GridHeight, 2f / Grid, 2f / GridHeight);
+
+        var byMotion = new RegionPlanner(options);
+        byMotion.Plan(Start, FrameWidth, FrameHeight, true, Still(), Grid, GridHeight, [], null, max, 1.0, min);
+        PlannedRegion motion = Assert.Single(byMotion.Plan(
+            Start.AddSeconds(1), FrameWidth, FrameHeight, true, Moving(30, 20, 2, 2), Grid, GridHeight,
+            [], null, max, 1.0, min));
+
+        var byTrack = new RegionPlanner(options);
+        byTrack.Plan(Start, FrameWidth, FrameHeight, true, Still(), Grid, GridHeight, [], null, max, 1.0, min);
+        PlannedRegion track = Assert.Single(byTrack.Plan(
+            Start.AddSeconds(1), FrameWidth, FrameHeight, true, Still(), Grid, GridHeight,
+            [new TrackedObject(1, "person", box, 0.9f, TrackState.Confirmed, Start, Start, 3)],
+            null, max, 1.0, min));
+
+        Assert.Equal(RegionReason.Motion, motion.Reason);
+        Assert.Equal(RegionReason.Track, track.Reason);
+        Assert.Equal(motion.Region, track.Region);
     }
 
     // ---- Crops shaped to the detector's aspect ----

--- a/Shared/Serval.Ai.Tests/TiledFloorTests.cs
+++ b/Shared/Serval.Ai.Tests/TiledFloorTests.cs
@@ -105,22 +105,75 @@ public class TiledFloorTests
         var options = new RegionOptions { TiledFloor = true };
         var input = new DetectorInput(640, 384, DetectorLayout.FloatNchw, 1f / 255f);
 
-        // 640x360 into 640x384 is scale 1.0 — the live 16:9 case, gain 1.0.
+        // 640x360 into 640x384 is scale 1.0 — a shape at the camera's own aspect, gain 1.0, nothing to
+        // recover by tiling.
         Assert.False(options.ShouldTileFloor(640, 360, input));
 
         // The panoramic into the same input is squeezed hard enough to qualify.
         Assert.True(options.ShouldTileFloor(1536, 432, input));
+
+        // The same 16:9 frame into a fixed square input is squeezed on the horizontal instead, and a
+        // 1.25x recovery is worth taking because none of it is invented.
+        Assert.True(options.ShouldTileFloor(640, 360, Square));
     }
 
     [Fact]
-    public void Tiling_is_independent_of_whether_cropping_is_on()
+    public void A_sweep_needs_cropping_because_a_tile_alone_cannot_confirm_a_track()
     {
-        // Deliberately separate switches. Cropping decides where to look opportunistically; this changes
-        // how the coverage guarantee itself is made, and must not arrive as a side effect of the other.
+        // The two option predicates disagree — tiling is asked for and cropping is not — and the planner
+        // resolves it toward the whole frame. That is not an oversight.
+        //
+        // A sweep examines a given pixel once per cycle, so the strips outside the tiles' overlap are
+        // seen once every six frames here. ObjectTracker drops a tentative track the moment one frame
+        // passes without matching it, and confirmation needs consecutive sightings, so a subject seen
+        // that rarely never confirms and never becomes an episode. Cropping is what bridges it: a
+        // retention crop is planned for every live track, tentative ones included.
+        //
+        // Six tiles, so this is the spread schedule. A sweep of at most RegionOptions.SweepAtOnce tiles
+        // is run whole on every frame instead, covers every pixel every frame, and needs nothing
+        // alongside it — see AcquisitionTests.
         var options = new RegionOptions { Mode = RegionMode.Off, TiledFloor = true };
 
         Assert.True(options.ShouldTileFloor(1536, 432, Square));
         Assert.False(options.ShouldCrop(1536, 432, Square));
+
+        var start = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.Zero);
+        IReadOnlyList<FrameRegion> tiles = DetectorShapes.Tiles(1536, 432, 320, 320, 0.2);
+        var planner = new RegionPlanner(options);
+
+        PlannedRegion only = Assert.Single(
+            planner.Plan(start, 1536, 432, cropping: false, default, 0, 0, [], tiles));
+
+        Assert.Equal(RegionReason.Floor, only.Reason);
+        Assert.Equal(new FrameRegion(0, 0, 1536, 432), only.Region);
+    }
+
+    [Fact]
+    public void A_swept_subject_is_re_sighted_by_a_retention_crop_on_the_next_frame()
+    {
+        // The acquisition path the coupling above buys. A tile finds something, the tracker holds it as
+        // tentative, and the very next frame plans a crop for it — so its sightings are consecutive and
+        // it can reach the confirmation ObjectTracker demands, rather than dying while the sweep is
+        // looking at another tile.
+        var options = new RegionOptions { TiledFloor = true, MaxPerFrame = 3, PaddingFraction = 0 };
+        var start = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.Zero);
+        IReadOnlyList<FrameRegion> tiles = DetectorShapes.Tiles(1536, 432, 320, 320, 0.2);
+        var planner = new RegionPlanner(options);
+
+        // Frame one sweeps the first tile.
+        Assert.Contains(
+            RegionReason.Tile,
+            planner.Plan(start, 1536, 432, true, default, 0, 0, [], tiles).Select(r => r.Reason));
+
+        // Frame two, with a tentative track where that tile found something.
+        var tentative = new TrackedObject(
+            1, "cat", new BoundingBox(0.05f, 0.4f, 0.04f, 0.15f), 0.4f,
+            TrackState.Tentative, start, start, 1);
+
+        IReadOnlyList<PlannedRegion> next = planner.Plan(
+            start.AddSeconds(0.5), 1536, 432, true, default, 0, 0, [tentative], tiles);
+
+        Assert.Contains(RegionReason.Track, next.Select(r => r.Reason));
     }
 
     private static IReadOnlyList<PlannedRegion> PlanAt(

--- a/deploy/examples/docker-compose.intel-coral.yml
+++ b/deploy/examples/docker-compose.intel-coral.yml
@@ -109,18 +109,29 @@ services:
       Serval__Ai__Detection__ScoreThreshold: "0.40"
 
       # An EdgeTPU graph is compiled for one shape, so every camera shares it and a wide frame is
-      # squeezed hard. Tiling sweeps native-scale tiles instead of one shrunken whole-frame look, at one
-      # tile per frame so the guaranteed cost stays flat. Off by default and left off on hosts without
-      # an accelerator.
+      # squeezed hard. Tiling sweeps native-scale tiles instead of one shrunken whole-frame look. Off by
+      # default and left off on hosts without an accelerator.
       #
-      # Which cameras qualify depends on the input size, and a LARGER input can switch this off. At 320
-      # a 640x360 stream sits at exactly the 2.0x threshold and tiles; at 512 it arrives at 0.80x, a
-      # 1.3x gain that is under both this threshold and the one enabling region crops at all, so it
-      # takes a single whole-frame pass instead. Measured across a 6-camera site, that moved reserved
-      # tile work from about 12/s to about 3/s.
+      # At 512 a 640x360 stream arrives at 0.80x, a 1.25x gain, and tiles TWO ways: 512x360 each, at
+      # x=0 and x=128 because the last tile sits flush to the far edge, overlapping by 384px. Two is at
+      # or under Regions__SweepAtOnce, so the sweep runs WHOLE on every frame — the entire picture
+      # examined exactly as often as under the shrunken pass it replaces, at 1.00x instead of 0.80x and
+      # 70% picture instead of 56%. Measured on a living-room camera with a cat in plain view over 92
+      # frames, that geometry took animal detections from 4 frames to 15.
       #
-      # The catch: a camera with crops off runs its whole-frame pass EVERY frame, and that pass is
-      # Floor, which InferenceScheduler never sheds. Cheaper in total, less sheddable under pressure.
+      # A longer sweep — the 1536x432 panoramic here needs four tiles — goes one tile per frame,
+      # restarting every FloorSeconds. THAT schedule needs region crops on alongside it and
+      # RegionPlanner enforces it: it examines a given pixel once per cycle, and a tentative track dies
+      # the moment one frame misses it, so without retention crops a new object never confirms.
+      #
+      # Cost: a run-whole sweep is two reserved inferences per frame per camera where the shrunken pass
+      # was one, and InferenceScheduler never sheds reserved work. Five 2-tile cameras plus the
+      # panoramic is about 22/s at DetectFps=2 against the ~31/s this host is budgeted for — check the
+      # "Detection budget" line before adding cameras.
+      #
+      # Do NOT reach for Regions__AutoMinRatio to get native scale on these cameras: turning crops on
+      # drops the whole-frame pass from every frame to once per FloorSeconds, and the smallest crop
+      # here is 512x360 — four fifths of the frame. It costs the schedule and buys nothing.
       Serval__Ai__Detection__Regions__TiledFloor: "true"
 
       # Regions__MinRegionScale is left at its 0.5 default here on purpose. 0.75 was measured as the
@@ -128,6 +139,13 @@ services:
       # 0.60 four, 0.50 two, not monotonic — but that number belongs to that model. The YOLOv9 head
       # above never mistook the same object at any scale, so tightening the bound for it would cost
       # inference and buy nothing. Re-measure on any model swap rather than carrying a value across.
+      #
+      # Regions__MaxRegionScale is the other end of that pair and is left at 1.0, which means a crop is
+      # never enlarged to reach the input. This is the setting a fixed square input most needs: without
+      # it the smallest crop on a 640x360 stream at 512 is blown up 3.2x, and a 2.75x enlargement was
+      # measured to find nothing at all where the unenlarged whole frame found a car in all 60 of 60
+      # frames. It costs no magnification that was ever real — a crop still arrives at the camera's full
+      # gain over the whole-frame pass. Moving it wants the same batch of frames MinRegionScale does.
 
       # --- the vision model, on the iGPU ---------------------------------------------------
       Serval__Ai__Vision__Enabled: "true"


### PR DESCRIPTION
## What this changes, and why

Fixes an alert issue, object detection improvement in some scenarios.

Closes #

## What you tested

<!-- Especially for camera-dependent work: name the camera and say what you saw. A reviewer
     probably cannot reproduce it. -->

## Checks

<!-- These are the same checks .github/workflows/ci.yml runs. Ticking them locally is faster than
     finding out from a red check. -->

- [x] `dotnet build Serval.slnx` — no warnings, not just no errors
- [x] `dotnet test Serval.slnx`
- [x] `dart format .` in `App/serval_app` reports no files changed
- [x] `flutter analyze` is silent, info included
- [x] `flutter test` passes — and if the design changed, `flutter test --update-goldens` and the
      new captures are committed in this branch
- [x] `pubspec.lock` is committed alongside any `pubspec.yaml` edit (CI resolves with
      `--enforce-lockfile`)
- [x] I have signed the [CLA](https://github.com/Flickersoft/serval/blob/main/CLA.md), or will when
      the bot asks
