### PR TITLE
Process/memory leak issue fix

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -20,6 +20,7 @@ television and have a public HTTPS endpoint. Everything else below is the engine
 | [live-view.md](live-view.md) | WebRTC via go2rtc, two-way talk-back, and ONVIF PTZ |
 | [configuration.md](configuration.md) | The three configuration tiers, the list-binding trap, the environment-only keys, and the CameraModule's settings |
 | [deployment.md](deployment.md) | Docker, the quickstart compose, the deployment examples, GPU offload, and logs |
+| [memory.md](memory.md) | What a camera costs, why an Intel host accounts the vision model as shared memory, and what the 90% warning is actually measuring |
 | [rk3588.md](rk3588.md) | Orange Pi 5 deployment and NPU vision |
 | [coral.md](coral.md) | Server deployment with Coral Edge TPUs: object detection on an accelerator, bring-up, and the failure modes |
 | [google-home.md](google-home.md) | Putting the cameras on a Nest Hub or a television: what it needs first, what leaves your network, and what to expose |

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -173,7 +173,9 @@ desktop core — fine for a handful of cameras at 1 fps, but an N100-class box r
 cameras wants an accelerator: measured ~96 inferences/s on two USB Corals against an estimated
 10–13/s on the N100's four cores (see [coral.md](coral.md)). Scene description on CPU takes tens
 of seconds per description on small hosts; a GPU brings it down ([below](#server-side-ai-on-a-gpu)).
-Budget ~8–10 GB of container memory with everything on, against ~2 GB for recording only.
+Budget ~8–10 GB of container memory with everything on, against ~2 GB for recording only;
+[memory.md](memory.md) breaks that down per camera and per model, and explains why an Intel host
+accounts the offloaded vision model outside the process.
 
 ## Secrets
 

--- a/Docs/memory.md
+++ b/Docs/memory.md
@@ -1,0 +1,137 @@
+# Memory
+
+Serval's memory is dominated by things that are not the server: one ffmpeg per stream, a model on
+the GPU, and page cache from writing recordings. The process itself is the smallest part of it. That
+is why the per-service `mem_limit` figures in [deploy/examples/](../deploy/examples/) look larger
+than the code would suggest, and why the number the app reports is not the number `docker stats`
+reports.
+
+Everything below was measured on one reference host unless it says otherwise: an Intel N100, four
+cores, 15.4 GiB usable, seven cameras, Coral USB detection, and the full AI stack with
+`GpuLayers=99`. Where a figure is estimated it says so.
+
+## The host budget
+
+The limits are per service and nothing adds them up for you:
+
+| Service | `mem_limit` | Measured | Notes |
+|---|---|---|---|
+| **server** | **12g** | 12.0 GiB charged, ~9.2 GiB working set | Fills its limit by design; see [below](#what-the-warning-measures) |
+| mongo | 2g | 632 MiB | Also capped at `--wiredTigerCacheSizeGB 1` |
+| go2rtc | 512m | 83 MiB | Only while a viewer is connected |
+
+That is 14.5 GiB of limits on a 15.4 GiB box. It does not overcommit in practice, because the
+server's limit is mostly reclaimable page cache that the kernel hands back under pressure rather
+than memory anyone is holding — but the arithmetic is worth knowing before raising anything. The
+example host at [docker-compose.intel-coral.yml](../deploy/examples/docker-compose.intel-coral.yml)
+ships `10g` for the same shape; the reference host runs `12g` because it carries seven cameras
+rather than six and every model enabled.
+
+## What a camera costs
+
+One ffmpeg per stream role, measured across seven cameras:
+
+| Session | Per camera | What it does |
+|---|---|---|
+| **detect + snapshot** | **~200 MB** | Sub stream: raw detect frames, JPEG stills, and the preview ring |
+| record | ~100 MB | Main stream, stream-copy to HLS — no decode, which is why it is the cheaper one |
+| audio tap | ~55 MB | Only on cameras with audio enabled |
+
+Seven cameras came to ~2,250 MB of ffmpeg. Budget **~300 MB per camera** with detection and
+recording both on, and note that the detect session is the expensive one because it is the only one
+that decodes: a recording is a copy.
+
+## The fixed stack
+
+- **`dotnet` itself: ~3.0 GB resident.** The managed heap, ONNX Runtime for the audio models, the
+  Coral runtime, and llama.cpp's host-side allocations. Not the vision model's weights — see below.
+- **Mongo: 632 MiB** against a 1 GB WiredTiger cache cap. It stays small and wants IOPS, not RAM.
+- **Page cache: whatever is left.** Recordings on their way to disk, reclaimable, and grown by the
+  kernel into whatever the limit leaves spare — so it is a consequence of the limit you set rather
+  than a cost to add up. On a busy recorder it is easily the largest line here. Not a leak, and not
+  something to tune.
+
+## Why Intel looks different
+
+With `GpuLayers` set, the vision model's weights, projector and KV cache do not appear anywhere in
+Serval's address space. i915 charges GEM buffers to whichever cgroup allocated them and accounts
+them as **shmem**, so on an Intel host the model shows up as ~2.9 GiB of shared memory that the
+process never maps. amdgpu accounts the same allocation elsewhere, which is why an AMD host's cgroup
+shows tens of MiB of shmem for the identical model and settings.
+
+The consequence is that `10g` on an Intel host is roughly 4 GB of headroom, not the 8 GB the process
+figures suggest.
+
+To confirm where it went, read the render node's own accounting rather than guessing from `ps`:
+
+```bash
+# The container's pid, not the server's own: pgrep -f matches its own command line too.
+PID=$(sudo docker inspect -f '{{.State.Pid}}' <server>)
+
+# The glob goes inside sudo — /proc/<pid>/fdinfo is unreadable to anyone else, so a shell
+# expanding it first finds nothing.
+sudo sh -c "grep -sH -E 'drm-resident-system0|drm-engine-render' /proc/$PID/fdinfo/*"
+#   /proc/2180/fdinfo/348:drm-resident-system0:  0
+#   /proc/2180/fdinfo/348:drm-engine-render:     0 ns
+#   /proc/2180/fdinfo/354:drm-resident-system0:  2942460 KiB          ← the model, on the iGPU
+#   /proc/2180/fdinfo/354:drm-engine-render:     24141437569132 ns    ← and doing work
+```
+
+There are two render-node handles and only one of them holds anything; that is normal. A large
+resident figure with `drm-engine-render` at zero would not be: it would mean memory was allocated
+and nothing ever ran on it.
+
+## What the warning measures
+
+The app warns at 90% of the container's limit, and the figure behind it is **not** `memory.current`.
+`MemoryStats.UsedBytes` is `memory.current` less `inactive_file`
+([CgroupV2.cs](../Server/Serval.Server/Vitals/CgroupV2.cs)) — reporting the raw figure would read as
+100% forever on any host whose media volume is not ZFS.
+
+Two things follow, and both surprise people:
+
+- **`active_file` is not subtracted.** On the reference host that is ~2.2 GiB of page cache —
+  genuinely reclaimable — counted against the threshold. The reported percentage is deliberately
+  conservative and reads high on a healthy NVR.
+- **`docker stats` will not agree with the app**, and the app is the one worth watching. `docker
+  stats` shows the charge including all cache.
+
+So the level itself says less than you would expect — where it settles depends on how many cameras
+are recording and how much limit is left for cache to grow into. What matters is the shape: a
+working set that rises and falls is cache doing its job, and one that climbs over days and never
+comes back down is something nobody is reaping.
+
+## The vision model
+
+Qwen3-VL-2B Q8_0 plus its mmproj is ~2.3 GB on disk and ~2.9 GiB resident once loaded and offloaded.
+It is the single largest consumer on the host and the only one where a smaller number is available
+for the asking: a Q4 quantisation roughly halves it. That is a quality trade, not free — see
+[deployment.md](deployment.md#server-side-ai-on-a-gpu) for what the offload buys and what it costs.
+
+Turning the vision model off entirely is the difference between the ~8–10 GB budget and the ~2 GB
+recording-only one quoted in the [root README](../README.md#storage-and-sizing).
+
+## When the number is wrong
+
+A working set that grows and never falls is a process nobody is reaping, not cache. The check is
+process counts, not memory:
+
+```bash
+pgrep -c ffprobe    # expect 0-2; a probe should live seconds
+pgrep -c ffmpeg     # expect roughly one per stream role, so ~2-3 per camera
+```
+
+What strands a process is a camera that stops answering without closing its TCP connection: the
+socket stays ESTABLISHED, RTSP carries no keepalive to discover the peer is gone, and anything
+reading it waits forever. Cameras do this, and nothing on this end can stop them.
+
+What Serval controls is whether that costs a process, and it is bounded in two places: a socket
+deadline handed to ffmpeg and ffprobe themselves
+([SourceArguments.cs](../Server/Serval.Server/Ingest/SourceArguments.cs)), which is what normally
+ends the child and lets it report why, and a kill of the whole process tree whenever a helper is
+abandoned ([ChildProcess.cs](../Server/Serval.Server/ChildProcess.cs)), which is what guarantees it
+even when the deadline does not fire. Disposing a process does neither — it releases the handle and
+leaves the child running — so the kill is deliberate rather than incidental.
+
+A count that keeps climbing therefore means one of those two is not holding, and that is where to
+look rather than at the memory figure.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ size retention to the disk. As anchors from real deployments: six cameras record
 streams write roughly 300–400 GB a day — seven days needs about 2.5 TB; sub-stream-only
 recording is orders of magnitude less. MongoDB stays small but wants IOPS — on a multi-disk
 host put it on the fast disk and the media on the big one. Memory: ~2 GB recording-only, 8–10 GB
-with the full AI stack loaded.
+with the full AI stack loaded — budget ~300 MB per camera on top of the models, and see
+[Docs/memory.md](Docs/memory.md) for the measurements and the host-level arithmetic.
 
 ## Security model
 

--- a/Server/Serval.Server.Tests/ChildProcessTests.cs
+++ b/Server/Serval.Server.Tests/ChildProcessTests.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Serval.Server;
+
+namespace Serval.Server.Tests;
+
+/// <summary>
+/// The teardown invariant that went missing at four of nine call sites, tested once.
+///
+/// The cost of it being absent was measured rather than imagined: a camera that stopped answering
+/// without closing its connection left one abandoned ffprobe per attempt, and a single incident on
+/// a seven-camera server accumulated thirty of them holding 1.6 GB. Every one was a process the
+/// code that started it believed it had disposed.
+/// </summary>
+public class ChildProcessTests
+{
+    private static bool CanRunPosixTools =>
+        OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
+
+    private static Process Start(string script) =>
+        Process.Start(new ProcessStartInfo("sh")
+        {
+            ArgumentList = { "-c", script },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        })!;
+
+    /// <summary>
+    /// The property <c>entireProcessTree</c> buys. ffmpeg spawns workers of its own, so killing
+    /// only the process this server started would leave them reparented onto init and running.
+    /// </summary>
+    [Fact]
+    public async Task Killing_a_process_takes_the_children_it_started_with_it()
+    {
+        if (!CanRunPosixTools)
+        {
+            Assert.Skip("Needs a POSIX shell.");
+        }
+
+        // Prints the grandchild's pid, then keeps the parent alive so the tree really is a tree.
+        using Process parent = Start("sleep 300 & echo $!; wait");
+        string firstLine = await parent.StandardOutput.ReadLineAsync() ?? "";
+        Assert.True(int.TryParse(firstLine.Trim(), out int grandchild), $"got '{firstLine}'");
+
+        ChildProcess.Kill(parent);
+        await parent.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        // The kill is asynchronous in the kernel; give the reap a moment rather than racing it.
+        bool gone = false;
+        for (int i = 0; i < 50 && !gone; i++)
+        {
+            gone = !ProcessIsAlive(grandchild);
+            if (!gone)
+            {
+                await Task.Delay(100, TestContext.Current.CancellationToken);
+            }
+        }
+
+        Assert.True(gone, $"pid {grandchild} outlived the kill.");
+    }
+
+    [Fact]
+    public async Task A_process_that_would_never_exit_is_gone_after_the_kill()
+    {
+        if (!CanRunPosixTools)
+        {
+            Assert.Skip("Needs a POSIX shell.");
+        }
+
+        using Process process = Start("sleep 300");
+        Assert.False(process.HasExited);
+
+        ChildProcess.Kill(process);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(process.HasExited);
+    }
+
+    /// <summary>
+    /// The race every one of the nine call sites swallows: the process ended between the check and
+    /// the kill, or never started at all. Both mean there is nothing to do, not something to report.
+    /// </summary>
+    [Fact]
+    public async Task Killing_a_process_that_has_already_exited_is_not_an_error()
+    {
+        if (!CanRunPosixTools)
+        {
+            Assert.Skip("Needs a POSIX shell.");
+        }
+
+        using Process process = Start("exit 0");
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        ChildProcess.Kill(process);
+        ChildProcess.Kill(process);
+    }
+
+    [Fact]
+    public void Killing_a_process_that_never_started_is_not_an_error()
+    {
+        using var process = new Process();
+        var logger = new CountingLogger();
+
+        ChildProcess.Kill(process, logger);
+
+        // Nothing was started, so nothing failed: this must not look like a process left running.
+        Assert.Equal(0, logger.Warnings);
+    }
+
+    /// <summary>
+    /// The half of the filter that can be forced safely. Warning on the ordinary race would put a
+    /// line in the log every time a helper finished normally, which is the failure mode that makes
+    /// people stop reading warnings.
+    ///
+    /// <para>The other half — a kill that fails with the process still running — has no safe
+    /// trigger here: the reliable way to earn a permission failure is to signal a process this user
+    /// does not own, and the one that is always present is pid 1.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_process_that_ended_on_its_own_is_not_reported_as_a_failure()
+    {
+        if (!CanRunPosixTools)
+        {
+            Assert.Skip("Needs a POSIX shell.");
+        }
+
+        using Process process = Start("exit 0");
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        var logger = new CountingLogger();
+        ChildProcess.Kill(process, logger);
+
+        Assert.Equal(0, logger.Warnings);
+    }
+
+    private sealed class CountingLogger : ILogger
+    {
+        public int Warnings { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Warning)
+            {
+                Warnings++;
+            }
+        }
+    }
+
+    private static bool ProcessIsAlive(int pid)
+    {
+        try
+        {
+            using Process found = Process.GetProcessById(pid);
+
+            // A killed child whose parent has not reaped it stays in the table as a zombie, which
+            // is exited for every purpose this asserts.
+            return !found.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}

--- a/Server/Serval.Server.Tests/ChildProcessTests.cs
+++ b/Server/Serval.Server.Tests/ChildProcessTests.cs
@@ -40,7 +40,8 @@ public class ChildProcessTests
 
         // Prints the grandchild's pid, then keeps the parent alive so the tree really is a tree.
         using Process parent = Start("sleep 300 & echo $!; wait");
-        string firstLine = await parent.StandardOutput.ReadLineAsync() ?? "";
+        string firstLine =
+            await parent.StandardOutput.ReadLineAsync(TestContext.Current.CancellationToken) ?? "";
         Assert.True(int.TryParse(firstLine.Trim(), out int grandchild), $"got '{firstLine}'");
 
         ChildProcess.Kill(parent);

--- a/Server/Serval.Server.Tests/RecordArgumentsTests.cs
+++ b/Server/Serval.Server.Tests/RecordArgumentsTests.cs
@@ -279,4 +279,16 @@ public class RecordArgumentsTests
         // capping them would slow the recording down to buy latency nobody is waiting on.
         Assert.DoesNotContain("-threads", Build(Spec(Transcode(), snapshot: true, detect: Detect())));
     }
+
+    [Fact]
+    public void The_sources_deadline_binds_to_the_input()
+    {
+        // After -i it binds to no input and the recording keeps the behaviour it was set to avoid:
+        // a camera that stops answering without closing its socket, and an ffmpeg blocked on it for
+        // as long as the process lives.
+        List<string> args = Build(Spec(Copy()));
+
+        Assert.True(args.IndexOf("-timeout") >= 0);
+        Assert.True(args.IndexOf("-timeout") < args.IndexOf("-i"));
+    }
 }

--- a/Server/Serval.Server.Tests/SourceArgumentsTests.cs
+++ b/Server/Serval.Server.Tests/SourceArgumentsTests.cs
@@ -19,7 +19,7 @@ public class SourceArgumentsTests
     {
         IReadOnlyList<string> args = SourceArguments.InputArgs(url);
 
-        Assert.Equal(["-rtsp_transport", "tcp", "-i", url], args);
+        Assert.Equal(["-rtsp_transport", "tcp", "-timeout", "30000000", "-i", url], args);
     }
 
     [Fact]
@@ -28,7 +28,10 @@ public class SourceArgumentsTests
         IReadOnlyList<string> args = SourceArguments.InputArgs("rtsp://cam/stream", audioOnly: true);
 
         Assert.Equal(
-            ["-rtsp_transport", "tcp", "-allowed_media_types", "audio", "-i", "rtsp://cam/stream"],
+            [
+                "-rtsp_transport", "tcp", "-allowed_media_types", "audio",
+                "-timeout", "30000000", "-i", "rtsp://cam/stream",
+            ],
             args);
     }
 
@@ -43,8 +46,10 @@ public class SourceArgumentsTests
     [InlineData("srt://cam:9000")]
     public void A_non_rtsp_network_source_gets_no_rtsp_options(string url)
     {
-        Assert.Equal(["-i", url], SourceArguments.InputArgs(url));
-        Assert.Equal(["-i", url], SourceArguments.InputArgs(url, audioOnly: true));
+        Assert.Equal(["-rw_timeout", "30000000", "-i", url], SourceArguments.InputArgs(url));
+        Assert.Equal(
+            ["-rw_timeout", "30000000", "-i", url],
+            SourceArguments.InputArgs(url, audioOnly: true));
     }
 
     [Theory]
@@ -71,14 +76,97 @@ public class SourceArgumentsTests
     public void Probing_an_rtsp_source_keeps_tcp_transport()
     {
         Assert.Equal(
-            ["-rtsp_transport", "tcp", "-i", "rtsp://cam/stream"],
+            ["-rtsp_transport", "tcp", "-timeout", "15000000", "-i", "rtsp://cam/stream"],
             SourceArguments.ProbeArgs("rtsp://cam/stream"));
     }
 
     [Fact]
     public void Probing_a_non_rtsp_source_passes_only_the_url()
     {
-        Assert.Equal(["-i", "rtmp://cam/live"], SourceArguments.ProbeArgs("rtmp://cam/live"));
+        Assert.Equal(
+            ["-rw_timeout", "15000000", "-i", "rtmp://cam/live"],
+            SourceArguments.ProbeArgs("rtmp://cam/live"));
+    }
+
+    // --- the socket deadline ------------------------------------------------------------------
+
+    /// <summary>
+    /// The regression suite for a leak that cost 1.6 GB per incident: a camera that stops answering
+    /// without closing its TCP connection leaves ffmpeg in <c>poll()</c> forever, because an RTSP
+    /// session carries no keepalive to discover the peer is gone. The deadline is what ends it, and
+    /// it is worthless after <c>-i</c>, where it binds to no input.
+    /// </summary>
+    [Theory]
+    [InlineData("rtsp://cam/stream")]
+    [InlineData("http://cam/stream.flv")]
+    [InlineData("srt://cam:9000")]
+    public void A_network_source_carries_its_deadline_before_the_input(string url)
+    {
+        List<string> args = [.. SourceArguments.InputArgs(url)];
+        int deadline = args.IndexOf("-timeout") >= 0
+            ? args.IndexOf("-timeout")
+            : args.IndexOf("-rw_timeout");
+
+        Assert.True(deadline >= 0);
+        Assert.True(deadline < args.IndexOf("-i"));
+    }
+
+    /// <summary>
+    /// Which option carries the deadline is protocol-private in the same way
+    /// <c>-rtsp_transport</c> is, and getting it wrong is worse than inert: on the RTMP protocol
+    /// <c>-timeout</c> means listen-seconds and implies <c>-rtmp_listen 1</c>, which would turn a
+    /// camera pull into a server waiting for an inbound connection.
+    /// </summary>
+    [Theory]
+    [InlineData("http://cam/stream.flv")]
+    [InlineData("rtmp://cam/live/stream")]
+    [InlineData("srt://cam:9000")]
+    public void Only_rtsp_gets_the_demuxers_own_timeout_option(string url)
+    {
+        Assert.DoesNotContain("-timeout", SourceArguments.InputArgs(url));
+        Assert.DoesNotContain("-timeout", SourceArguments.ProbeArgs(url));
+        Assert.Contains("-rw_timeout", SourceArguments.InputArgs(url));
+    }
+
+    /// <summary>
+    /// <c>-rw_timeout</c> is silently ignored by the RTSP demuxer, so the two are an either/or
+    /// rather than a belt-and-braces pair.
+    /// </summary>
+    [Fact]
+    public void An_rtsp_source_never_gets_the_generic_avio_option()
+    {
+        Assert.DoesNotContain("-rw_timeout", SourceArguments.InputArgs("rtsp://cam/stream"));
+        Assert.DoesNotContain("-rw_timeout", SourceArguments.ProbeArgs("rtsp://cam/stream"));
+    }
+
+    /// <summary>A local read cannot half-open, so there is no deadline worth setting on one.</summary>
+    [Theory]
+    [InlineData("/videos/sample.mp4")]
+    [InlineData("file:///videos/sample.mp4")]
+    public void A_file_source_gets_no_deadline(string url)
+    {
+        Assert.DoesNotContain("-timeout", SourceArguments.InputArgs(url));
+        Assert.DoesNotContain("-rw_timeout", SourceArguments.InputArgs(url));
+        Assert.DoesNotContain("-rw_timeout", SourceArguments.ProbeArgs(url));
+    }
+
+    /// <summary>
+    /// ffmpeg takes microseconds. The conversion is culture-invariant because the one host that
+    /// would break — a comma-decimal locale — would produce a command line that fails on every
+    /// camera at once, and only there.
+    /// </summary>
+    [Fact]
+    public void The_deadline_is_written_in_invariant_microseconds()
+    {
+        List<string> args = [.. SourceArguments.ProbeArgs("rtsp://cam/stream")];
+        string value = args[args.IndexOf("-timeout") + 1];
+
+        Assert.Equal(
+            ((long)SourceArguments.ProbeTimeout.TotalMicroseconds).ToString(
+                System.Globalization.CultureInfo.InvariantCulture),
+            value);
+        Assert.DoesNotContain(',', value);
+        Assert.DoesNotContain('.', value);
     }
 
     [Theory]

--- a/Server/Serval.Server.Tests/SourceProbeTests.cs
+++ b/Server/Serval.Server.Tests/SourceProbeTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging.Abstractions;
 using Serval.Server.Ingest;
 
@@ -25,6 +26,8 @@ public class SourceProbeTests : IDisposable
 
     public void Dispose() => Directory.Delete(_root, recursive: true);
 
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("macos")]
     private static bool CanRunPosixTools =>
         OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
 
@@ -37,9 +40,15 @@ public class SourceProbeTests : IDisposable
     {
         string path = Path.Combine(_root, "wedged-ffprobe");
         File.WriteAllText(path, "#!/bin/sh\nwhile :; do echo y; done\n");
-        File.SetUnixFileMode(
-            path,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        // Every caller is already behind this guard. Repeated inside the method because the
+        // platform analyzer follows a check it can see here, not one two frames up the stack.
+        if (CanRunPosixTools)
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
 
         return path;
     }

--- a/Server/Serval.Server.Tests/SourceProbeTests.cs
+++ b/Server/Serval.Server.Tests/SourceProbeTests.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Serval.Server.Ingest;
+
+namespace Serval.Server.Tests;
+
+/// <summary>
+/// The leak, reproduced without a camera.
+///
+/// A probe abandoned on its deadline used to leave the process running: the timeout cancelled the
+/// await, and disposing a <see cref="Process"/> releases the handle without ending the child. On a
+/// supervisor that retries a wedged source that is one orphan per attempt, each holding its
+/// connection open — thirty of them, and 1.6 GB, from a single incident on a real server.
+///
+/// <para>Slow, and it earns it the way <see cref="IngestStallWatchdogTests"/> does: a process that
+/// really hangs is the only way to tell a bounded wait from an unbounded one, and the failure it
+/// guards is silent.</para>
+/// </summary>
+public class SourceProbeTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"serval-probe-{Guid.NewGuid():N}");
+
+    public SourceProbeTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    private static bool CanRunPosixTools =>
+        OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
+
+    /// <summary>
+    /// A stand-in for the camera that fails both ways the real one did at once: it ignores every
+    /// argument it is handed, so it never exits on its own, and it floods stdout, so a probe that
+    /// drained neither pipe would block here too.
+    /// </summary>
+    private string WedgedProbe()
+    {
+        string path = Path.Combine(_root, "wedged-ffprobe");
+        File.WriteAllText(path, "#!/bin/sh\nwhile :; do echo y; done\n");
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        return path;
+    }
+
+    private static int LiveChildren(string path) =>
+        Process.GetProcesses().Count(p =>
+        {
+            try
+            {
+                return p.ProcessName is "sh" or "wedged-ffprobe" && !p.HasExited;
+            }
+            catch
+            {
+                return false;
+            }
+        });
+
+    [Fact]
+    public async Task A_source_that_never_answers_is_given_up_on_and_leaves_nothing_running()
+    {
+        if (!CanRunPosixTools)
+        {
+            Assert.Skip("Needs a POSIX shell.");
+        }
+
+        string ffprobe = WedgedProbe();
+        int before = LiveChildren(ffprobe);
+        var elapsed = Stopwatch.StartNew();
+
+        VideoProbe probe = await SourceProbe.VideoAsync(
+            "rtsp://camera.invalid/stream",
+            ffprobe,
+            "cam-1",
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        elapsed.Stop();
+
+        // A source that says nothing is a null answer, not an exception: the caller decides whether
+        // it can build a session without one.
+        Assert.Null(probe.Codec);
+        Assert.Null(probe.Width);
+        Assert.Null(probe.Height);
+
+        // Bounded by the probe's own deadline, with nothing else cancelling it. Compared generously
+        // against the deadline rather than to it, so this measures that a bound exists rather than
+        // what it is set to.
+        Assert.True(
+            elapsed.Elapsed < SourceArguments.ProbeTimeout + TimeSpan.FromSeconds(30),
+            $"took {elapsed.Elapsed.TotalSeconds:0.0}s, so nothing bounded it.");
+
+        // The kill happens inside the probe; the kernel reaps asynchronously.
+        int after = before;
+        for (int i = 0; i < 50; i++)
+        {
+            after = LiveChildren(ffprobe);
+            if (after <= before)
+            {
+                break;
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(after <= before, $"left a probe behind: {before} before, {after} after.");
+    }
+
+    [Fact]
+    public async Task A_probe_that_cannot_start_answers_null_rather_than_throwing()
+    {
+        VideoProbe probe = await SourceProbe.VideoAsync(
+            "rtsp://camera.invalid/stream",
+            Path.Combine(_root, "no-such-ffprobe"),
+            "cam-1",
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(probe.Codec);
+    }
+}

--- a/Server/Serval.Server/Ai/CameraAiCoordinator.cs
+++ b/Server/Serval.Server/Ai/CameraAiCoordinator.cs
@@ -534,9 +534,22 @@ public sealed class CameraAiCoordinator : BackgroundService
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
+                // Asked for the same reason the detect reader asks: re-subscribing cannot conjure
+                // snapshots nobody is writing, so rebuilding this half alone would time out again
+                // at every idle period, forever. The request reaches a session only where one is
+                // registered, which is exactly the camera whose snapshots come from a detect
+                // session of its own — a camera served by its recording session registers nothing
+                // and keeps that session, which its own watchdog is already covering.
+                //
+                // For a camera running descriptions with object detection off this is the only
+                // path to ingest there is, because the detect reader that would otherwise carry it
+                // is never started.
                 _logger.LogWarning(
-                    "Camera {CameraId}: no snapshot for {Seconds:0}s; restarting its AI session.",
+                    "Camera {CameraId}: no snapshot for {Seconds:0}s; restarting its AI session "
+                    + "and asking its ingest session to restart.",
                     camera.Id, idleTimeout.TotalSeconds);
+
+                _detectRestarts.Request(camera.Id);
                 return;
             }
 

--- a/Server/Serval.Server/Ai/FfmpegAudioSession.cs
+++ b/Server/Serval.Server/Ai/FfmpegAudioSession.cs
@@ -100,10 +100,7 @@ public sealed class FfmpegAudioSession
         {
             await linked.CancelAsync();
 
-            if (!process.HasExited)
-            {
-                try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
-            }
+            ChildProcess.Kill(process, _logger);
 
             try { await stderrPump; } catch { /* shutting down */ }
         }
@@ -145,11 +142,37 @@ public sealed class FfmpegAudioSession
         var bytes = new byte[ReadBufferBytes];
         var samples = new float[ReadBufferBytes / 2];
         int carry = 0;
+        TimeSpan stallTimeout = TimeSpan.FromSeconds(_options.StallTimeoutSeconds);
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            int read = await process.StandardOutput.BaseStream.ReadAsync(
-                bytes.AsMemory(carry, bytes.Length - carry), cancellationToken);
+            int read;
+
+            // Arriving bytes are the only sign this tap is alive: stdout carries the audio itself,
+            // so there is no progress stream to watch the way a recording session's is watched. A
+            // source that stops answering without closing delivers neither samples nor EOF, and the
+            // read would otherwise wait on it for as long as the process lives.
+            using (var idle = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                if (stallTimeout > TimeSpan.Zero)
+                {
+                    idle.CancelAfter(stallTimeout);
+                }
+
+                try
+                {
+                    read = await process.StandardOutput.BaseStream.ReadAsync(
+                        bytes.AsMemory(carry, bytes.Length - carry), idle.Token);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // Ahead of the exit code, which reports the kill in the caller's finally rather
+                    // than the reason for it.
+                    throw new InvalidOperationException(
+                        $"ffmpeg audio for camera '{_camera.Id}' produced nothing for "
+                        + $"{stallTimeout.TotalSeconds:0}s and was killed.");
+                }
+            }
 
             if (read == 0)
             {

--- a/Server/Serval.Server/ChildProcess.cs
+++ b/Server/Serval.Server/ChildProcess.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+
+namespace Serval.Server;
+
+/// <summary>
+/// The teardown every process this server starts needs, in one place.
+///
+/// In the root namespace because the callers are spread across ingest, clip export and the AI
+/// audio tap, and none of them should have to reference another's namespace to end a process it
+/// started.
+/// </summary>
+internal static class ChildProcess
+{
+    /// <summary>
+    /// Ends a process and everything it started, if it is still running.
+    ///
+    /// This exists because <see cref="Process.Dispose"/> does not do it: disposing releases the
+    /// handle and leaves the child running, so a helper abandoned on a timeout survives the code
+    /// that was waiting for it and is never reaped. On a retry loop that is one leaked process per
+    /// attempt for as long as the source stays wedged.
+    ///
+    /// <see cref="Process.Kill(bool)"/> is a SIGKILL on Linux, which is what a wedged ffmpeg needs:
+    /// it never reaches the handler a polite signal would rely on. The whole tree, because ffmpeg
+    /// spawns its own workers and killing only the parent orphans them onto init.
+    /// </summary>
+    /// <param name="logger">
+    /// Where a kill that genuinely failed is reported — a process this server started that is still
+    /// out there is worth a line. Optional only for the startup capability probe, which runs before
+    /// the host is built and has no logger to hand.
+    /// </param>
+    public static void Kill(Process process, ILogger? logger = null)
+    {
+        // HasExited is inside the try: it throws for a process that never started and for one
+        // already disposed, which are two more ways of being gone.
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception) when (HasGone(process))
+        {
+            // The ordinary case, and the reason this is a filter rather than a bare catch: the
+            // process ended on its own between the check and the signal. Asking again settles it
+            // without naming a kernel error code, which is the part that differs by platform.
+            // Anything the process outlives falls through to the warning below.
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(
+                ex,
+                "Could not end process {Pid}; it may still be running. Serval will not try again.",
+                PidOf(process));
+        }
+    }
+
+    /// <summary>
+    /// Whether there is no longer a running process here — exited, never started, or disposed.
+    /// Every one of those means the kill has nothing left to do.
+    /// </summary>
+    private static bool HasGone(Process process)
+    {
+        try
+        {
+            return process.HasExited;
+        }
+        catch (InvalidOperationException)
+        {
+            // No process is associated with this object: it was never started, or it has been
+            // disposed — ObjectDisposedException derives from this one, so both land here.
+            return true;
+        }
+    }
+
+    /// <summary>The pid for a log line, or null when the object cannot supply one.</summary>
+    private static int? PidOf(Process process)
+    {
+        try
+        {
+            return process.Id;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// How long a short-lived helper reading local media — a frame, a duration, a stream layout —
+    /// is given before it is abandoned and killed.
+    ///
+    /// Generous, because it bounds a failure rather than describing normal work: these finish in
+    /// well under a second on a healthy disk, and the value only matters when the media is on a
+    /// mount that has stopped answering. Cancelling the caller stays the faster path.
+    /// </summary>
+    public static readonly TimeSpan HelperTimeout = TimeSpan.FromSeconds(60);
+}

--- a/Server/Serval.Server/Clips/ClipMedia.cs
+++ b/Server/Serval.Server/Clips/ClipMedia.cs
@@ -179,29 +179,46 @@ public sealed class ClipMedia
             startInfo.ArgumentList.Add(arg);
         }
 
+        Process? process = null;
         try
         {
-            using Process process = Process.Start(startInfo)
+            process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("Could not start ffmpeg to sample a frame.");
 
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(ChildProcess.HelperTimeout);
+
             using var buffer = new MemoryStream();
-            Task copy = process.StandardOutput.BaseStream.CopyToAsync(buffer, cancellationToken);
-            Task<string> errors = process.StandardError.ReadToEndAsync(cancellationToken);
+            Task copy = process.StandardOutput.BaseStream.CopyToAsync(buffer, deadline.Token);
+            Task<string> errors = process.StandardError.ReadToEndAsync(deadline.Token);
 
             await copy;
             await errors;
-            await process.WaitForExitAsync(cancellationToken);
+            await process.WaitForExitAsync(deadline.Token);
 
             return process.ExitCode == 0 ? buffer.ToArray() : null;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogDebug("Gave up sampling a frame at {Offset}s from {Clip}.", offset, clipPath);
+            return null;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Could not sample a frame at {Offset}s from {Clip}.", offset, clipPath);
             return null;
         }
+        finally
+        {
+            if (process is not null)
+            {
+                ChildProcess.Kill(process, _logger);
+                process.Dispose();
+            }
+        }
     }
 
-    private static async Task<(int ExitCode, string Output)> RunAsync(
+    private async Task<(int ExitCode, string Output)> RunAsync(
         string executable,
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken,
@@ -222,13 +239,23 @@ public sealed class ClipMedia
         using Process process = Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Could not start {executable}.");
 
-        // Both pipes are read before waiting: a process that fills one while nobody drains it
-        // blocks forever, and ffmpeg is chatty on stderr.
-        Task<string> output = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        Task<string> errors = process.StandardError.ReadToEndAsync(cancellationToken);
+        try
+        {
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(ChildProcess.HelperTimeout);
 
-        await process.WaitForExitAsync(cancellationToken);
+            // Both pipes are read before waiting: a process that fills one while nobody drains it
+            // blocks forever, and ffmpeg is chatty on stderr.
+            Task<string> output = process.StandardOutput.ReadToEndAsync(deadline.Token);
+            Task<string> errors = process.StandardError.ReadToEndAsync(deadline.Token);
 
-        return (process.ExitCode, captureStandardOutput ? await output : await errors);
+            await process.WaitForExitAsync(deadline.Token);
+
+            return (process.ExitCode, captureStandardOutput ? await output : await errors);
+        }
+        finally
+        {
+            ChildProcess.Kill(process, _logger);
+        }
     }
 }

--- a/Server/Serval.Server/Ingest/FfmpegCapabilities.cs
+++ b/Server/Serval.Server/Ingest/FfmpegCapabilities.cs
@@ -61,7 +61,7 @@ public sealed class FfmpegCapabilities
             output = process.StandardOutput.ReadToEnd();
             if (!process.WaitForExit((int)timeout.TotalMilliseconds))
             {
-                try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
+                ChildProcess.Kill(process);
                 throw new FfmpegUnavailableException(
                     $"'{ffmpegPath} -encoders' did not finish within {timeout.TotalSeconds:0}s.");
             }

--- a/Server/Serval.Server/Ingest/FfmpegRunner.cs
+++ b/Server/Serval.Server/Ingest/FfmpegRunner.cs
@@ -106,13 +106,9 @@ internal static class FfmpegRunner
         finally
         {
             // ffmpeg exited, stalled, or we were cancelled — stop the helper loops and the process
-            // tree. Kill is a SIGKILL on Linux, which is what a wedged ffmpeg needs: it never
-            // reaches the handler a polite signal would rely on.
+            // tree.
             linked.Cancel();
-            if (!process.HasExited)
-            {
-                try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
-            }
+            ChildProcess.Kill(process, logger);
 
             await Task.WhenAll(running.Select(Swallow));
         }

--- a/Server/Serval.Server/Ingest/SourceArguments.cs
+++ b/Server/Serval.Server/Ingest/SourceArguments.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Serval.Server.Ingest;
 
 /// <summary>
@@ -14,6 +16,22 @@ namespace Serval.Server.Ingest;
 /// </summary>
 internal static class SourceArguments
 {
+    /// <summary>
+    /// Socket I/O deadline for a live session's input. A camera that stops answering without
+    /// closing its connection leaves ffmpeg in <c>poll()</c> forever — the peer vanished without a
+    /// FIN and an RTSP session carries no keepalive to discover that — so without a deadline the
+    /// process outlives every attempt to replace it. Sits below
+    /// <see cref="IngestOptions.StallTimeoutSeconds"/> so ffmpeg reports the failure itself rather
+    /// than the watchdog taking the blame for it, and above the longest normal gap between packets.
+    /// </summary>
+    private static readonly TimeSpan SourceTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The same deadline for a probe, which is shorter because it has no stall watchdog behind it:
+    /// a probe runs before there is a stream to watch, so this is the only bound on it.
+    /// </summary>
+    public static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(15);
+
     /// <summary>Schemes the server knows how to pull. Anything else is rejected at validation.</summary>
     private static readonly IReadOnlySet<string> SupportedSchemes =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -35,7 +53,8 @@ internal static class SourceArguments
     {
         if (IsFile(url))
         {
-            // Loop the file forever, paced to realtime so it behaves like a live camera.
+            // Loop the file forever, paced to realtime so it behaves like a live camera. A local
+            // read cannot half-open, so there is no timeout worth setting on one.
             return ["-stream_loop", "-1", "-re", "-i", url];
         }
 
@@ -48,13 +67,14 @@ internal static class SourceArguments
                 args.AddRange(["-allowed_media_types", "audio"]);
             }
 
+            args.AddRange(TimeoutArgs(url, SourceTimeout));
             args.AddRange(["-i", url]);
             return args;
         }
 
         // http(s) / rtmp(s) / srt: the demuxer's defaults are what we want, and none of the RTSP
         // options apply.
-        return ["-i", url];
+        return [.. TimeoutArgs(url, SourceTimeout), "-i", url];
     }
 
     /// <summary>
@@ -63,7 +83,35 @@ internal static class SourceArguments
     /// exit with an unrecognised-option error, so a file source gets nothing but its path.
     /// </summary>
     public static IReadOnlyList<string> ProbeArgs(string url) =>
-        IsRtsp(url) ? ["-rtsp_transport", "tcp", "-i", url] : ["-i", url];
+        IsRtsp(url)
+            ? ["-rtsp_transport", "tcp", .. TimeoutArgs(url, ProbeTimeout), "-i", url]
+            : [.. TimeoutArgs(url, ProbeTimeout), "-i", url];
+
+    /// <summary>
+    /// The demuxer's socket I/O timeout, in microseconds, or nothing when the caller passed zero or
+    /// the source is a local file.
+    ///
+    /// Which option carries it is scheme-private, the same trap the rest of this class exists for:
+    /// the RTSP demuxer declares its own <c>-timeout</c>, while every other network scheme takes
+    /// the generic AVIO <c>-rw_timeout</c>. Both must precede <c>-i</c> to bind to the input.
+    ///
+    /// An either/or rather than a pair, in both directions. <c>-rw_timeout</c> is silently ignored
+    /// by the RTSP demuxer, so it would buy nothing there. <c>-timeout</c> on RTMP is a different
+    /// option that happens to share the name — listen-seconds, implying <c>-rtmp_listen 1</c> —
+    /// so sending it there would turn a camera pull into a server waiting to be connected to.
+    /// </summary>
+    private static IReadOnlyList<string> TimeoutArgs(string url, TimeSpan readTimeout)
+    {
+        if (readTimeout <= TimeSpan.Zero || IsFile(url))
+        {
+            return [];
+        }
+
+        string microseconds = ((long)readTimeout.TotalMicroseconds)
+            .ToString(CultureInfo.InvariantCulture);
+
+        return IsRtsp(url) ? ["-timeout", microseconds] : ["-rw_timeout", microseconds];
+    }
 
     /// <summary>
     /// True for <c>rtsp://</c> and <c>rtsps://</c>. Callers use this for the handful of behaviours

--- a/Server/Serval.Server/Ingest/SourceProbe.cs
+++ b/Server/Serval.Server/Ingest/SourceProbe.cs
@@ -17,8 +17,12 @@ internal sealed record VideoProbe(string? Codec, int? Width, int? Height);
 /// </summary>
 internal static class SourceProbe
 {
-    /// <summary>How long a wedged source is given before its probe is abandoned.</summary>
-    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+    /// <summary>
+    /// How long a wedged source is given past the deadline ffprobe was handed before it is
+    /// abandoned and killed. The margin is what makes the usual failure ffprobe's own error, with a
+    /// reason attached, rather than a kill that reports nothing about the source.
+    /// </summary>
+    private static readonly TimeSpan Timeout = SourceArguments.ProbeTimeout + TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Codec and dimensions in one call, since a second ffprobe means a second chance to stall on a
@@ -85,29 +89,44 @@ internal static class SourceProbe
             startInfo.ArgumentList.Add(arg);
         }
 
+        Process? probe = null;
         try
         {
-            using var probe = Process.Start(startInfo);
+            probe = Process.Start(startInfo);
             if (probe is null)
             {
                 return [];
             }
 
-            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeout.CancelAfter(Timeout);
+            using var abandon = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            abandon.CancelAfter(Timeout);
 
-            string output = await probe.StandardOutput.ReadToEndAsync(timeout.Token);
-            await probe.WaitForExitAsync(timeout.Token);
+            // Both pipes are read before waiting: a process that fills one while nobody drains it
+            // blocks in write() forever, which is a hang no timeout on the source can end.
+            Task<string> output = probe.StandardOutput.ReadToEndAsync(abandon.Token);
+            Task<string> errors = probe.StandardError.ReadToEndAsync(abandon.Token);
+            await probe.WaitForExitAsync(abandon.Token);
+
+            string fields = await output;
+            await errors;
 
             // One value per line, in the order asked for. Blank lines are kept so a missing middle
             // field cannot shift the ones after it into the wrong slots.
-            return output.ReplaceLineEndings("\n").TrimEnd('\n').Split('\n');
+            return fields.ReplaceLineEndings("\n").TrimEnd('\n').Split('\n');
         }
         catch (Exception ex)
         {
             logger.LogWarning(
                 ex, "ffprobe ({Stream}) failed for camera {CameraId}.", streamSpecifier, cameraId);
             return [];
+        }
+        finally
+        {
+            if (probe is not null)
+            {
+                ChildProcess.Kill(probe, logger);
+                probe.Dispose();
+            }
         }
     }
 }

--- a/Server/Serval.Server/Ingest/StreamIngestManager.cs
+++ b/Server/Serval.Server/Ingest/StreamIngestManager.cs
@@ -245,6 +245,16 @@ public sealed class StreamIngestManager : BackgroundService
     private TimeSpan MaxBackoff => TimeSpan.FromSeconds(_options.CurrentValue.Ingest.MaxReconnectSeconds);
 
     /// <summary>
+    /// How long an attempt must last to count as having worked, and so to earn the next failure a
+    /// fresh base delay rather than the escalated one its predecessors built up.
+    ///
+    /// A fixed span rather than something derived from <see cref="MaxBackoff"/>: an operator who
+    /// raises the reconnect ceiling to an hour is asking for a longer wait between tries, not for
+    /// an hour of uptime before a camera is considered to have started successfully.
+    /// </summary>
+    private static readonly TimeSpan HealthyRun = TimeSpan.FromSeconds(60);
+
+    /// <summary>
     /// The ingest settings a session is built from — those that reach a command line, and
     /// <see cref="IngestOptions.StallTimeoutSeconds"/>, which the session reads once when it arms
     /// its watchdog. Both are fixed for the life of a session, so both need one to restart before a
@@ -355,11 +365,13 @@ public sealed class StreamIngestManager : BackgroundService
                     ? _detectRestarts.Register(camera.Id, () => RequestStop(attempt))
                     : null;
 
+                DateTimeOffset startedAt = DateTimeOffset.UtcNow;
+                bool misconfigured = false;
+                Exception? fault = null;
+
                 try
                 {
                     await run(attempt.Token);
-                    // A clean exit resets the backoff.
-                    backoff = TimeSpan.FromSeconds(_options.CurrentValue.Ingest.ReconnectSeconds);
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
@@ -379,13 +391,11 @@ public sealed class StreamIngestManager : BackgroundService
                         "Camera {CameraId} {Role} stream cannot start: {Reason} This will not fix "
                         + "itself — edit the camera or the server configuration.",
                         camera.Id, role, ex.Message);
-                    backoff = MaxBackoff;
+                    misconfigured = true;
                 }
                 catch (Exception ex)
                 {
-                    sessionLogger.LogError(ex,
-                        "Camera {CameraId} {Role} stream failed; reconnecting in {Backoff}.",
-                        camera.Id, role, backoff);
+                    fault = ex;
                 }
 
                 // Reported here rather than from a catch, because a requested restart has two
@@ -394,17 +404,37 @@ public sealed class StreamIngestManager : BackgroundService
                 // the token it was handed is the one that stopped it — so the usual ending is a
                 // clean return, and the exception is only what a cancel before ffmpeg started
                 // produces.
-                //
-                // Neither is a fault or a dead source, so the backoff earned by whatever the
-                // session was doing before the request is dropped; this goes round again at the
-                // base delay.
                 if (attempt.IsCancellationRequested && !cts.IsCancellationRequested)
                 {
                     sessionLogger.LogInformation(
                         "Camera {CameraId} {Role} stream restarting: its frames stopped reaching "
                         + "the AI session.",
                         camera.Id, role);
+                }
+
+                // Uptime is what earns a reset, not how the attempt ended. A session that carried
+                // frames for a while and then lost its reader has proved the source is there and
+                // should come straight back; one that ended in seconds has proved nothing, however
+                // it ended.
+                //
+                // The ending cannot be the test because the AI half asks for a restart every ten
+                // seconds for as long as its frames are missing, which is exactly the state a
+                // camera that cannot start at all is in. Counting those as successes would pin the
+                // backoff at its base delay and retry a dead camera every few seconds forever.
+                if (misconfigured)
+                {
+                    backoff = MaxBackoff;
+                }
+                else if (DateTimeOffset.UtcNow - startedAt >= HealthyRun)
+                {
                     backoff = TimeSpan.FromSeconds(_options.CurrentValue.Ingest.ReconnectSeconds);
+                }
+
+                if (fault is not null)
+                {
+                    sessionLogger.LogError(fault,
+                        "Camera {CameraId} {Role} stream failed; reconnecting in {Backoff}.",
+                        camera.Id, role, backoff);
                 }
 
                 try

--- a/Server/Serval.Server/Media/CastTranscoder.cs
+++ b/Server/Serval.Server/Media/CastTranscoder.cs
@@ -249,10 +249,7 @@ public sealed class CastTranscoder
         }
         finally
         {
-            if (!process.HasExited)
-            {
-                try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
-            }
+            ChildProcess.Kill(process, _logger);
 
             // The viewer seeking away closes the response mid-copy, which leaves the feed writing
             // into a pipe whose process has just been killed. Somebody has to observe that.

--- a/Server/Serval.Server/Media/ClipExporter.cs
+++ b/Server/Serval.Server/Media/ClipExporter.cs
@@ -443,10 +443,7 @@ public sealed class ClipExporter
 
     private async Task CleanUpAsync(Export export)
     {
-        if (!export.Process.HasExited)
-        {
-            try { export.Process.Kill(entireProcessTree: true); } catch { /* already gone */ }
-        }
+        ChildProcess.Kill(export.Process, _logger);
 
         // Both are already awaited on the happy path; awaiting again is free. This is for the path
         // where the destination went away: the feed is writing into a pipe whose process we just
@@ -556,19 +553,23 @@ public sealed class ClipExporter
             startInfo.ArgumentList.Add(arg);
         }
 
+        Process? probe = null;
         try
         {
-            using Process? probe = Process.Start(startInfo);
+            probe = Process.Start(startInfo);
             if (probe is null)
             {
                 return null;
             }
 
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(ChildProcess.HelperTimeout);
+
             // Both pipes are read before waiting: a process that fills one while nobody drains it
             // blocks forever.
-            Task<string> output = probe.StandardOutput.ReadToEndAsync(cancellationToken);
-            Task<string> errors = probe.StandardError.ReadToEndAsync(cancellationToken);
-            await probe.WaitForExitAsync(cancellationToken);
+            Task<string> output = probe.StandardOutput.ReadToEndAsync(deadline.Token);
+            Task<string> errors = probe.StandardError.ReadToEndAsync(deadline.Token);
+            await probe.WaitForExitAsync(deadline.Token);
 
             string streams = (await output).Trim();
             await errors;
@@ -577,10 +578,23 @@ public sealed class ClipExporter
                 ? string.Join(" | ", streams.Split('\n').Select(l => l.Trim()))
                 : null;
         }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("Gave up reading the stream layout of {Init}.", initPath);
+            return null;
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Could not read the stream layout of {Init}.", initPath);
             return null;
+        }
+        finally
+        {
+            if (probe is not null)
+            {
+                ChildProcess.Kill(probe, _logger);
+                probe.Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
## What this changes, and why

Fixed a hanging process memory leak issue

Closes #


## Checks

<!-- These are the same checks .github/workflows/ci.yml runs. Ticking them locally is faster than
     finding out from a red check. -->

- [x] `dotnet build Serval.slnx` — no warnings, not just no errors
- [x] `dotnet test Serval.slnx`
- [x] `dart format .` in `App/serval_app` reports no files changed
- [x] `flutter analyze` is silent, info included
- [x] `flutter test` passes — and if the design changed, `flutter test --update-goldens` and the
      new captures are committed in this branch
- [x] `pubspec.lock` is committed alongside any `pubspec.yaml` edit (CI resolves with
      `--enforce-lockfile`)
- [x] I have signed the [CLA](https://github.com/Flickersoft/serval/blob/main/CLA.md), or will when
      the bot asks
